### PR TITLE
fix: Add environment to GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,9 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This commit fixes the deployment workflow by adding the required `environment` key to the `build-and-deploy` job.

Newer versions of the `actions/deploy-pages` action require an explicit environment to be set for security and traceability. This change specifies the standard `github-pages` environment, which resolves the 'Missing environment' error encountered during deployment.