### PR TITLE
fix: Rewrite relative image paths to be absolute

### DIFF
--- a/build.py
+++ b/build.py
@@ -123,15 +123,24 @@ def process_article(article_dir):
         if first_p:
             summary = first_p.get_text()
 
-        image_url = soup.find('img')['src'] if soup.find('img') else None
+        # Rewrite image paths to be absolute
+        for img in soup.find_all('img'):
+            if img['src'] and not img['src'].startswith('http'):
+                img['src'] = f"https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/{article_dir['name']}/{img['src']}"
+
+        # Get the first image for the summary card
+        main_image_url = soup.find('img')['src'] if soup.find('img') else None
+
+        # Get the final HTML content after modifications
+        final_html_content = str(soup)
 
         slug = article_dir['name']
 
         return {
             "title": title,
             "summary": summary,
-            "image_url": image_url,
-            "html_content": html_content,
+            "image_url": main_image_url,
+            "html_content": final_html_content,
             "slug": slug,
             "path": f"{slug}.html"
         }

--- a/dist/01-L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo.html
+++ b/dist/01-L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo.html
@@ -162,165 +162,86 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>L'Intelligenza Artificiale: Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo</h1>
-
 <p>di: <em>Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_1.jpg" alt="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_1.jpg" /></p>
-
+<img alt="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_1.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/01-L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo/Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_1.jpg"/></p>
 <p>Se vi state chiedendo cosa sia realmente l'Intelligenza Artificiale e perché se ne parli così tanto, non siete soli. In questo momento storico, stiamo assistendo a una rivoluzione silenziosa ma potentissima che sta cambiando il modo in cui lavoriamo, impariamo e interagiamo con il mondo digitale. L'Intelligenza Artificiale (AI) non è più fantascienza: è qui, ora, e probabilmente la state già usando senza rendervene conto.</p>
-
 <p>Quando aprite Netflix e vi vengono suggeriti film perfetti per i vostri gusti, quando chiedete a Siri di impostare una sveglia, o quando Google Traduttore vi aiuta a comprendere un testo in lingua straniera, state interagendo con sistemi di AI. Ma cosa si nasconde dietro questa tecnologia che sembra quasi magica?</p>
-
 <p>L'Intelligenza Artificiale è una branca dell'informatica il cui obiettivo principale è creare sistemi e algoritmi capaci di svolgere compiti che, fino a poco tempo fa, erano esclusivo appannaggio dell'intelligenza umana. Questi compiti spaziano dal ragionamento e dall'apprendimento alla pianificazione, dalla percezione (sia essa visiva o vocale) alla comprensione del linguaggio naturale, fino alla risoluzione di problemi complessi.</p>
-
 <h2>Un Campo Interdisciplinare con Radici Profonde</h2>
-
 <p>Per comprendere davvero l'AI, dobbiamo prima sfatare un mito: non si tratta solo di programmazione informatica. L'AI è un campo interdisciplinare che attinge a piene mani da diverse aree del sapere, come un puzzle complesso i cui pezzi provengono da discipline apparentemente distanti.</p>
-
 <p>L'informatica fornisce le basi teoriche e pratiche essenziali per lo sviluppo di algoritmi e sistemi computazionali. È il linguaggio con cui parliamo alle macchine. La matematica, con concetti quali l'algebra lineare, il calcolo e la statistica, è la grammatica di questo linguaggio: senza di essa, i modelli di AI non potrebbero "imparare" dai dati.</p>
-
 <p>Le neuroscienze offrono ispirazione cruciale, studiando il funzionamento del cervello umano per informare lo sviluppo delle reti neurali artificiali. È affascinante pensare che i ricercatori osservano come i nostri neuroni si connettono e comunicano per replicare questi processi in silicio e codice.</p>
-
 <p>La psicologia contribuisce attraverso lo studio del comportamento e dei processi cognitivi umani, aiutando a creare sistemi di AI che possano interagire con noi in modo più naturale. La linguistica è cruciale per l'elaborazione del linguaggio naturale (NLP), permettendo alle macchine di comprendere, interpretare e generare il linguaggio umano. Infine, l'ingegneria è essenziale per la progettazione e l'implementazione concreta dei sistemi AI, sia a livello software che hardware.</p>
-
 <h2>L'Evoluzione di un'Idea Rivoluzionaria: Dalla Teoria alla Rivoluzione Quotidiana</h2>
-
 <p>La storia dell'AI è una saga affascinante di sogni visionari, delusioni cocenti e trionfi inaspettati. Sebbene l'AI sia diventata un fenomeno di massa solo negli ultimi anni, le sue radici affondano negli anni '40 e '50, quando pionieri come Alan Turing iniziarono a esplorare l'idea di macchine intelligenti.</p>
-
 <p>Nel 1950, Turing propose il celebre Test di Turing, un criterio apparentemente semplice ma rivoluzionario per valutare se una macchina potesse essere considerata "intelligente": se un essere umano non riusciva a distinguere, in una conversazione, tra le risposte di una macchina e quelle di un altro essere umano, allora quella macchina poteva essere considerata intelligente. Era un'idea audace per l'epoca, quando i computer occupavano intere stanze e faticavano a fare calcoli che oggi il nostro smartphone esegue in millisecondi.</p>
-
 <p>La nascita formale dell'AI come disciplina scientifica è spesso ricondotta alla Conferenza di Dartmouth nel 1956, dove un gruppo di ricercatori visionari si riunì con l'ambizioso obiettivo di "far sì che le macchine usino il linguaggio, formino astrazioni e concetti, risolvano problemi ora riservati agli umani e si migliorino da sole".</p>
-
 <p>L'evoluzione dell'AI è stata un viaggio caratterizzato da periodi di grande entusiasmo alternati a fasi di "inverno", in cui le aspettative si scontravano brutalmente con le limitazioni tecnologiche dell'epoca. Dopo una fase iniziale teorica, si passò a un periodo di simulazione (anni '60-'80) con lo sviluppo dei sistemi esperti, programmi basati su regole logiche per risolvere problemi specifici, e i primi passi nell'elaborazione del linguaggio naturale con chatbot primitivi come ELIZA, che simulava uno psicoterapeuta con risposte pre-programmate.</p>
-
 <p>Gli anni '80 e '90 videro l'ascesa delle reti neurali artificiali e dell'apprendimento automatico (Machine Learning), tecnologie che imitano il funzionamento del cervello umano e permettono alle macchine di imparare dai dati invece di seguire solo regole rigide.</p>
-
 <p>La fase moderna, dal 1990 ad oggi, è l'era dei Big Data e del Deep Learning. La crescente disponibilità di enormi dataset e l'incremento esponenziale della potenza di calcolo hanno permesso ai modelli di apprendimento automatico e, in particolare, alle reti neurali profonde (con molti strati, da cui "deep") di raggiungere prestazioni straordinarie in compiti complessi come il riconoscimento di immagini, il riconoscimento vocale e la traduzione automatica.</p>
-
 <h2>L'Era dei Modelli Fondazionali: Quando l'AI Ha Imparato a Parlare Come Noi</h2>
-
 <p>Il 2022 ha segnato uno spartiacque nella storia dell'intelligenza artificiale. Nel 2025, aziende come OpenAI, Google, Anthropic e nuovi concorrenti come DeepSeek hanno ampliato i confini di ciò che i grandi modelli linguistici (LLM) possono fare. Ma tutto è iniziato con il lancio di ChatGPT da parte di OpenAI nel novembre 2022, un evento che ha catapultato l'AI dalla nicchia tecnologica al dibattito pubblico globale.</p>
-
 <p>Improvvisamente, milioni di persone potevano conversare con una macchina in linguaggio naturale, chiedere spiegazioni complesse, ottenere aiuto nella scrittura, nella programmazione, persino nella risoluzione di problemi creativi. Non era più necessario essere programmatori o esperti di tecnologia: bastava porre una domanda come si farebbe con un amico particolarmente colto.</p>
-
 <p>I Large Language Models (LLM) rappresentano un salto qualitativo enorme rispetto ai chatbot del passato. Questi sistemi, addestrati su enormi quantità di testo proveniente da internet, libri, articoli e documenti, hanno sviluppato una comprensione sorprendentemente sofisticata del linguaggio umano. Ma la vera magia non sta solo nella loro capacità di comprendere: è nella loro abilità di generare risposte coerenti, creative e contestualmente appropriate.</p>
-
 <p>Oggi il panorama è dominato da alcuni giganti principali, ma sta rapidamente evolvendosi. ChatGPT di OpenAI rimane il più famoso e continua a evolversi con versioni sempre più potenti. Google ha risposto con Gemini (precedentemente Bard), integrando profondamente l'AI in tutto il suo ecosistema di servizi. Anthropic ha sviluppato Claude, noto per la sua sicurezza e la capacità di gestire conversazioni lunghe e complesse. Ma il 2025 ha visto l'emergere di un nuovo protagonista che ha scosso l'intero settore: DeepSeek, la startup cinese che ha innescato un crollo di oltre mille miliardi di dollari nei mercati azionari globali con un modello AI di ragionamento a basso costo che ha superato molti concorrenti occidentali. La loro app mobile è balzata in cima alle classifiche dell'App Store di Apple, superando persino ChatGPT, dimostrando come l'innovazione AI possa emergere da contesti inaspettati e ridefinire rapidamente gli equilibri di mercato.</p>
-
 <p>Ma la vera rivoluzione è stata democratica: per la prima volta nella storia, tecnologie AI all'avanguardia sono diventate accessibili a chiunque abbia una connessione internet. Studenti usano questi strumenti per comprendere concetti difficili, scrittori per superare il blocco creativo, programmatori per debug del codice, professionisti per redigere email e relazioni.</p>
-
 <p>Parallelamente ai modelli testuali, abbiamo assistito all'esplosione dell'AI multimodale. Sistemi come GPT-4 Vision possono "vedere" e descrivere immagini, DALL-E e Midjourney creano opere d'arte partendo da descrizioni testuali, mentre strumenti come Runway generano video da semplici prompt. La barriera tra immaginazione e creazione digitale si sta assottigliando rapidamente.</p>
-
 <h2>Le Diverse Anime dell'AI: Una Mappa per Orientarsi</h2>
-
 <p>Per navigare in questo panorama complesso, è utile distinguere tra diverse tipologie di AI in base alle loro capacità, come fossero diverse specie di un ecosistema tecnologico in rapida evoluzione.</p>
-
 <p><strong>ANI (Artificial Narrow Intelligence)</strong>: È la forma di AI più diffusa oggi e quella con cui interagiamo quotidianamente. È specializzata nell'eseguire un compito molto specifico, come il riconoscimento facciale nelle foto, la traduzione automatica, o la raccomandazione di contenuti su piattaforme di streaming. Le sue capacità sono impressionanti ma limitate a quel singolo dominio: un sistema eccellente nel riconoscere volti non saprà tradurre testi.</p>
-
 <p><strong>AGI (Artificial General Intelligence)</strong>: Questo è il Santo Graal di molti ricercatori e il protagonista di innumerevoli dibattiti. Un'AGI possiederebbe un'intelligenza generale comparabile a quella umana, in grado di comprendere, apprendere e applicare l'intelligenza per risolvere qualsiasi compito intellettuale che un essere umano può affrontare. Potrebbe passare dall'analizzare dati finanziari alla composizione di poesie, dalla risoluzione di problemi matematici alla comprensione di sfumature emotive, tutto con la stessa versatilità di una mente umana. Non è ancora stata realizzata, ma gli esperti dibattono intensamente se e quando potrebbe emergere.</p>
-
 <p><strong>ASI (Artificial Super Intelligence)</strong>: Un concetto puramente teorico al momento, che fa tremare i polsi a ricercatori e futurologi. Un'ASI supererebbe l'intelligenza umana in tutti i campi, inclusa la creatività, la risoluzione di problemi e il ragionamento scientifico. Rappresenta sia il sogno ultimo di efficienza e progresso, sia l'incubo di una tecnologia che potrebbe sfuggire al controllo umano.</p>
-
 <p>Oltre a queste classificazioni basate sul "livello" di intelligenza, è importante comprendere gli approcci chiave che stanno alimentando l'AI moderna. Il Machine Learning è il motore che permette alle macchine di imparare dai dati senza essere esplicitamente programmate per ogni situazione. Il Deep Learning, un sottocampo del Machine Learning, utilizza reti neurali con molti strati per riconoscere pattern complessi nei dati.</p>
-
 <p>Gli Algoritmi Generativi rappresentano una frontiera particolarmente affascinante: invece di limitarsi a classificare o analizzare dati esistenti, questi sistemi possono creare nuovi contenuti - testi, immagini, musica, persino codice di programmazione - apprendendo i pattern dai dati di addestramento e generando variazioni originali.</p>
-
 <h2>IA Generativa: Quando le Macchine Diventano Creative</h2>
-
 <p>Se dovessimo identificare il fenomeno più dirompente degli ultimi anni nell'AI, sarebbe senza dubbio l'emergere dell'intelligenza artificiale generativa. Questa tecnologia ha ribaltato il paradigma tradizionale dell'informatica: invece di seguire istruzioni precise per produrre risultati prevedibili, l'AI generativa crea contenuti originali partendo da semplici descrizioni in linguaggio naturale.</p>
-
 <p>Immaginate di poter descrivere a parole un'immagine nella vostra mente e vedere un computer disegnarla per voi. O di poter chiedere la composizione di una melodia in stile jazz degli anni '40 e riceverla in pochi secondi. Questo non è più fantascienza: è la realtà quotidiana di milioni di utenti che utilizzano strumenti come DALL-E, Midjourney, Stable Diffusion per la generazione di immagini, o Suno e Udio per la creazione musicale.</p>
-
 <p>L'impatto sulla creatività umana è profondo e controverso. Da un lato, questi strumenti democratizzano la creazione artistica: chiunque può ora produrre immagini professionali, comporre musica, o scrivere storie senza anni di formazione tecnica. Dall'altro, sollevano questioni fondamentali sui diritti d'autore, l'originalità artistica e il futuro delle professioni creative.</p>
-
 <p>Nel mondo della programmazione, l'AI generativa ha creato una rivoluzione silenziosa ma potentissima. GitHub Copilot, sviluppato in collaborazione con OpenAI, può scrivere codice completo partendo da commenti in linguaggio naturale. Programmatori esperti riferiscono di essere diventati significativamente più produttivi, mentre principianti possono affrontare progetti complessi con un supporto intelligente che era impensabile solo pochi anni fa.</p>
-
 <p>La sintesi vocale e la clonazione di voci hanno raggiunto livelli di realismo impressionanti. Sistemi come ElevenLabs possono replicare la voce di una persona partendo da pochi minuti di registrazione audio, aprendo possibilità incredibili per il doppiaggio, l'audiobook personalizzato, ma anche sollevando preoccupazioni legittime sui deepfake audio e la disinformazione.</p>
-
 <h2>Applicazioni Attuali e Emergenti: L'AI nella Vita Quotidiana</h2>
-
 <p>L'intelligenza artificiale ha ormai permeato quasi ogni aspetto della nostra vita quotidiana, spesso in modi così sottili che non ce ne accorgiamo nemmeno. Ma oltre alle applicazioni ormai consolidate, stanno emergendo utilizzi che promettono di trasformare settori cruciali della società.</p>
-
 <p>Nell'educazione, l'AI sta personalizzando l'apprendimento come mai prima d'ora. Piattaforme come Khan Academy utilizzano algoritmi intelligenti per adattare il ritmo e lo stile di insegnamento alle esigenze specifiche di ogni studente. Sistemi di tutoring AI possono identificare le lacune di conoscenza individuali e proporre esercizi mirati, mentre strumenti di valutazione automatica permettono ai docenti di concentrarsi più sul mentoring che sulla correzione meccanica.</p>
-
 <p>Nel campo della ricerca scientifica, l'AI sta accelerando scoperte che richiederebbero decenni di lavoro umano. DeepMind's AlphaFold ha risolto uno dei problemi più complessi della biologia - la predizione della struttura delle proteine - aprendo nuove frontiere nella ricerca medica e farmaceutica. In astronomia, algoritmi di machine learning analizzano enormi dataset telescopici per identificare nuovi pianeti, stelle e fenomeni cosmici.</p>
-
 <p>La medicina di precisione sta beneficiando enormemente dell'AI. Sistemi di diagnosi assistita possono identificare tumori in immagini mediche con precisione superiore ai radiologi umani, mentre algoritmi predittivi aiutano a identificare pazienti a rischio prima che sviluppino sintomi gravi. Durante la pandemia COVID-19, l'AI ha accelerato lo sviluppo di vaccini e aiutato a modellare la diffusione del virus.</p>
-
 <p>Nel settore finanziario, l'AI non si limita più al trading algoritmico. Sistemi intelligenti valutano il rischio creditizio considerando migliaia di variabili, scoprono frodi in tempo reale e forniscono consulenza finanziaria personalizzata a milioni di utenti attraverso robo-advisor.</p>
-
 <p>L'automazione industriale sta vivendo una seconda rivoluzione grazie all'AI. Fabbriche intelligenti utilizzano sistemi di visione computerizzata per il controllo qualità, algoritmi predittivi per la manutenzione preventiva e robot collaborativi che lavorano fianco a fianco con gli operatori umani.</p>
-
 <h2>Sfide e Opportunità Future: Navigare Verso un'AI Responsabile</h2>
-
 <p>Mentre ci avviciniamo rapidamente a un futuro sempre più integrato con l'intelligenza artificiale, emergono sfide complesse che richiedono una gestione attenta e lungimirante. La regolamentazione rappresenta una delle frontiere più critiche e urgenti.</p>
-
 <p>La legge sull'intelligenza artificiale è entrata in vigore il 1° agosto 2024 e sarà pienamente applicabile due anni dopo, il 2 agosto 2026., segnando l'Europa come pioniera nella regolamentazione dell'AI a livello globale. L'AI Act europeo rappresenta il primo tentativo comprensivo di creare un framework legale per l'intelligenza artificiale, classificando i sistemi AI in base al rischio e imponendo obblighi proporzionali. I nuovi obblighi applicabili ai modelli di intelligenza artificiale di uso generale (inclusi modelli linguistici di grandi dimensioni come ChatGPT, Gemini, Claude e Grok) sottolineano la trasparenza e le responsabilità in materia di copyright.</p>
-
 <p>Questo approccio normativo non è solo burocratico: riflette una comprensione matura che l'AI, come tutte le tecnologie potenti, deve essere guidata da principi etici chiari. Le aziende tecnologiche si trovano ora ad affrontare requisiti di trasparenza che erano impensabili solo pochi anni fa, dovendo spiegare come i loro algoritmi prendono decisioni che influenzano milioni di vite.</p>
-
 <p>La sostenibilità energetica rappresenta un'altra sfida cruciale spesso sottovalutata dal pubblico generale. L'addestramento di modelli AI avanzati richiede quantità enormi di energia elettrica. GPT-4, per esempio, ha richiesto mesi di calcolo su migliaia di chip grafici ad alte prestazioni. Questo solleva questioni ambientali serie: come bilanciare i benefici dell'AI con il suo impatto carbonico? Le aziende stanno investendo in data center alimentati da energie rinnovabili e sviluppando algoritmi più efficienti, ma la sfida rimane aperta.</p>
-
 <p>Quando si parla di Artificial General Intelligence (AGI), le opinioni degli esperti si dividono drasticamente. Alcuni ricercatori prevedono il raggiungimento dell'AGI entro i prossimi 10-20 anni, mentre altri ritengono che siamo ancora molto lontani da questo traguardo. La verità è che non esiste una definizione universalmente accettata di cosa costituisca effettivamente un'AGI, rendendo difficile anche valutare i progressi verso questo obiettivo.</p>
-
 <p>Ciò che è certo è che il percorso verso sistemi AI più generali e capaci richiederà non solo progressi tecnologici, ma anche una riflessione profonda su come integrare queste tecnologie nella società in modo benefico per tutti. La questione non è se l'AGI arriverà, ma come prepararci per gestire le sue implicazioni.</p>
-
 <h2>L'AI e le Sfide Etiche: Quando la Tecnologia Incontra i Valori Umani</h2>
-
 <p>L'espansione rapida dell'intelligenza artificiale ha portato alla luce dilemmi etici che la società non aveva mai affrontato prima. Questi non sono problemi astratti da discutere nei laboratori universitari: sono questioni concrete che influenzano già oggi le nostre vite in modi significativi.</p>
-
 <p>La gestione di grandi quantità di dati necessari per addestrare i modelli pone interrogativi fondamentali sulla privacy e sulla sicurezza delle informazioni personali. Ogni volta che interagiamo con un sistema AI, generiamo dati che possono essere utilizzati per migliorare questi sistemi, ma anche per tracciare, profilare e influenzare i nostri comportamenti. La domanda diventa: chi controlla questi dati e come vengono utilizzati?</p>
-
 <p>I modelli di AI possono ereditare e amplificare i bias presenti nei dati di addestramento, portando a decisioni discriminatorie o ingiuste in aree critiche come la selezione del personale, la valutazione del credito, o persino la giustizia penale. Un algoritmo addestrato su dati storici che riflettono pregiudizi sociali può perpetuare e istituzionalizzare questi pregiudizi su scala massiva, creando sistemi di discriminazione automatizzata particolarmente insidiosi perché nascosti dietro un'apparente oggettività matematica.</p>
-
 <p>L'emergere dei deepfake rappresenta una minaccia crescente all'integrità dell'informazione. La capacità di creare video e audio falsi ma convincenti di personaggi pubblici sta alimentando preoccupazioni legittime sulla disinformazione e la manipolazione dell'opinione pubblica. In un'epoca già segnata da "post-verità" e fake news, i deepfake aggiungono un ulteriore livello di complessità alla sfida di distinguere tra realtà e finzione.</p>
-
 <p>I diritti d'autore nell'era dell'AI generativa stanno creando un terreno di battaglia legale complesso. Quando un'AI crea un'immagine, una melodia o un testo, chi ne possiede i diritti? E cosa succede quando l'AI è stata addestrata su opere protette da copyright senza il consenso esplicito degli autori originali? Artisti, scrittori e musicisti stanno intentando cause legali contro le aziende di AI, sostenendo che i loro lavori sono stati utilizzati illegalmente per addestrare sistemi commerciali.</p>
-
 <p>La trasparenza degli algoritmi rappresenta un'altra frontiera cruciale. Molti sistemi AI moderni, specialmente quelli basati su deep learning, sono "scatole nere": funzionano efficacemente, ma è difficile o impossibile spiegare esattamente come arrivino a una specifica decisione. Questo è problematico quando questi sistemi vengono utilizzati in contesti ad alto impatto come la medicina, la giustizia o la finanza, dove la capacità di spiegare e giustificare le decisioni è essenziale.</p>
-
 <h2>L'Automazione e il Futuro del Lavoro: Trasformazione, Non Solo Distruzione</h2>
-
 <p>Una delle preoccupazioni più diffuse riguardo all'AI è il suo impatto sul lavoro umano. I titoli sensazionalistici spesso parlano di "robot che rubano posti di lavoro", ma la realtà è più sfumata e complessa. L'automazione spinta dall'AI sta certamente trasformando il panorama lavorativo, ma sta anche creando nuove opportunità che erano impensabili solo pochi anni fa.</p>
-
 <p>È vero che alcuni lavori ripetitivi e basati su regole fisse stanno scomparendo o si stanno riducendo significativamente. Call center automatizzati gestiscono sempre più richieste di customer service, software di contabilità automatizzano compiti che richiedevano ore di lavoro manuale, e sistemi di traduzione automatica stanno cambiando il mercato dei servizi linguistici.</p>
-
 <p>Tuttavia, parallelamente stanno emergendo nuove professioni e specializzazioni. "Prompt engineer" - esperti nella comunicazione efficace con sistemi AI - è diventato un ruolo ricercato e ben retribuito. Specialisti in etica dell'AI, supervisori di sistemi automatizzati, e "AI trainer" che si occupano di addestrare e affinare modelli di intelligenza artificiale rappresentano nuove categorie professionali in rapida crescita.</p>
-
 <p>Molti lavori, invece di scomparire, si stanno evolvendo verso una collaborazione uomo-macchina. Medici utilizzano AI per diagnosi più precise ma mantengono il controllo delle decisioni terapeutiche e della relazione con i pazienti. Avvocati utilizzano sistemi intelligenti per ricerca legale e analisi di documenti, ma rimangono insostituibili per strategia, negoziazione e rappresentanza in tribunale. Designer collaborano con AI generativa per esplorare rapidamente diverse opzioni creative, ma il gusto, la visione e la comprensione del contesto culturale rimangono distintamente umani.</p>
-
 <p>La chiave per navigare questa transizione è l'adattabilità e l'apprendimento continuo. Le competenze più resistenti all'automazione sono quelle che richiedono creatività, empatia, pensiero critico complesso e capacità di lavorare in situazioni ambigue e non strutturate. Investire in queste competenze "umane" diventa cruciale in un mondo sempre più automatizzato.</p>
-
 <h2>Una Guida per Navigare nel Futuro: Cosa Significa Tutto Questo per Voi?</h2>
-
 <p>Comprendere l'Intelligenza Artificiale, le sue basi teoriche, la sua evoluzione, le sue applicazioni e le sue implicazioni non è più un lusso per appassionati di tecnologia: è diventata una necessità per navigare consapevolmente nel panorama contemporaneo. Ma cosa significa concretamente tutto questo per la persona comune?</p>
-
 <p>Prima di tutto, significa sviluppare una "alfabetizzazione digitale" che includa una comprensione di base di come funzionano questi sistemi. Non dovete diventare programmatori, ma comprendere che l'AI impara dai dati, che può avere bias, che non è infallibile, e che le sue risposte devono essere valutate criticamente vi renderà utenti più consapevoli e efficaci.</p>
-
 <p>Significa anche esplorare attivamente come l'AI può migliorare la vostra vita professionale e personale. Se siete studenti, sistemi come ChatGPT o Claude possono diventare tutor personalizzati per aiutarvi a comprendere concetti difficili. Se lavorate in ufficio, strumenti AI possono automatizzare compiti ripetitivi liberando tempo per attività più creative e strategiche. Se siete creativi, l'AI generativa può diventare un partner per esplorare nuove idee e superare blocchi creativi.</p>
-
 <p>Tuttavia, è cruciale sviluppare anche una consapevolezza critica. Interrogatevi sempre sull'origine e l'affidabilità delle informazioni fornite da sistemi AI. Comprendete che questi strumenti riflettono i dati e i valori con cui sono stati addestrati. Mantenete il controllo delle decisioni importanti invece di delegarle completamente agli algoritmi.</p>
-
 <p>L'obiettivo di questa esplorazione dell'AI non è solo educare, ma anche ispirare curiosità e creatività nell'uso di queste tecnologie. L'AI è uno strumento potentissimo, ma rimane sempre uno strumento: il suo valore dipende da come lo utilizziamo e dagli obiettivi che ci poniamo.</p>
-
 <h2>Guardando al Futuro: L'AI Come Amplificatore dell'Umanità</h2>
-
 <p>Mentre concludiamo questo viaggio attraverso il mondo dell'intelligenza artificiale, è importante mantenere una prospettiva bilanciata. L'AI non è né la panacea per tutti i problemi dell'umanità né l'apocalisse tecnologica temuta dai catastrofisti. È una tecnologia potente che amplifica le capacità umane, con tutto ciò che questo comporta di positivo e negativo.</p>
-
 <p>Gli anni che abbiamo davanti saranno cruciali per determinare la direzione di questa rivoluzione tecnologica. Le scelte che facciamo oggi - come individui, come società, come specie - riguardo allo sviluppo, alla regolamentazione e all'implementazione dell'AI definiranno il tipo di futuro che stiamo costruendo.</p>
-
 <p>La sfida non è fermare il progresso tecnologico - sarebbe impossibile e controproducente - ma guidarlo in modo che rifletta i nostri valori più alti e serva il bene comune. Questo richiede un impegno attivo da parte di tutti: cittadini informati che partecipano al dibattito pubblico, policymaker che creano regolamentazioni ponderate, ricercatori che sviluppano tecnologie responsabili, e aziende che danno priorità all'impatto sociale oltre al profitto.</p>
-
 <p>L'intelligenza artificiale rappresenta probabilmente il più grande amplificatore di capacità umane mai creato. Come ogni amplificatore, non cambia la natura del segnale che riceve, ma lo rende più potente. Se alimentiamo l'AI con saggezza, creatività e compassione, otterremo una tecnologia che amplifica questi aspetti migliori dell'umanità. Se invece la sviluppiamo guidati solo da profitto a breve termine o da visioni ristrette, rischiamo di amplificare anche i nostri difetti e pregiudizi.</p>
-
 <h2>Conclusioni: Il Nostro Ruolo nell'Era dell'AI</h2>
-
 <p>In sintesi, l'Intelligenza Artificiale è una forza potente e trasformativa che sta plasmando il nostro futuro in modi inimmaginabili. Non è una tecnologia che ci capita addosso passivamente: siamo tutti attori in questa trasformazione, con la responsabilità e l'opportunità di influenzarne la direzione.</p>
-
 <p>La vera rivoluzione non sta nella tecnologia stessa, ma in come scegliamo di integrarla nelle nostre vite e nella nostra società. Bilanciare l'innovazione con la consapevolezza delle implicazioni etiche e sociali sarà la chiave per garantire che questa tecnologia sia utilizzata per potenziare l'umanità e costruire un mondo migliore per tutti.</p>
-
 <p>Il futuro dell'AI non è predeterminato: siamo noi a scriverlo, una decisione alla volta, una applicazione alla volta, una regolamentazione alla volta. E per farlo bene, dobbiamo tutti diventare cittadini digitali consapevoli, capaci di navigare con saggezza in questo nuovo mondo che stiamo creando insieme alle macchine intelligenti.</p>
-
-<p>Questa è la sfida e l'opportunità del nostro tempo: non solo utilizzare l'AI, ma plasmarla in modo che rifletta il meglio di ciò che significa essere umani. <img src="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_3.jpg" alt="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_3.jpg" /></p>
+<p>Questa è la sfida e l'opportunità del nostro tempo: non solo utilizzare l'AI, ma plasmarla in modo che rifletta il meglio di ciò che significa essere umani. <img alt="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_3.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/01-L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo/Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_3.jpg"/></p>
 
             <div class="footer-back-button">
                 <a href="index.html" class="back-button">Torna indietro</a>

--- a/dist/02-Machine Learning, Deep Learning e Algoritmi Generativi Il Cuore Pulsante dell'Intelligenza Artificiale Moderna.html
+++ b/dist/02-Machine Learning, Deep Learning e Algoritmi Generativi Il Cuore Pulsante dell'Intelligenza Artificiale Moderna.html
@@ -162,170 +162,101 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>Machine Learning, Deep Learning e Algoritmi Generativi: Il Cuore Pulsante dell'Intelligenza Artificiale Moderna</h1>
-
 <p>di: <em>Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_2.jpg" alt="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_2.jpg" /></p>
-
+<img alt="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_2.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/02-Machine Learning, Deep Learning e Algoritmi Generativi Il Cuore Pulsante dell'Intelligenza Artificiale Moderna/Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_2.jpg"/></p>
 <p><em>Dopo aver esplorato le fondamenta storiche e tecniche dell'Intelligenza Artificiale nel nostro precedente articolo, approfondiamo ora le tecnologie che stanno realmente rivoluzionando il nostro mondo: il Machine Learning, il Deep Learning e gli algoritmi generativi. Questi strumenti non sono più fantascienza, ma realtà quotidiana che plasma il modo in cui lavoriamo, comunichiamo e creiamo.</em></p>
-
 <h2>L'Era dell'Apprendimento Automatico: Quando le Macchine Imparano da Sole</h2>
-
 <h3>La Rivoluzione Silenziosa del Machine Learning</h3>
-
 <p>Il Machine Learning (ML) rappresenta oggi la spina dorsale di quasi tutto ciò che definiamo "intelligente" nel mondo tecnologico. Con l'avanzare del 2025, l'Intelligenza Artificiale Spiegabile (xAI) sta diventando uno standard aziendale, segnando un'evoluzione importante da algoritmi "scatola nera" verso sistemi trasparenti e comprensibili.</p>
-
 <p>Ma cosa significa realmente Machine Learning? Immaginiamo di insegnare a un bambino a riconoscere gli animali: gli mostriamo migliaia di foto di gatti e cani, spiegandogli le differenze. Gradualmente, il bambino sviluppa la capacità di distinguere autonomamente tra i due animali, anche di fronte a foto mai viste prima. Il Machine Learning funziona in modo simile: gli algoritmi "osservano" grandi quantità di dati, identificano pattern nascosti e sviluppano la capacità di fare previsioni accurate su nuove informazioni.</p>
-
 <h3>I Tre Pilastri dell'Apprendimento Automatico</h3>
-
 <h4>Apprendimento Supervisionato: La Guida del Maestro</h4>
-
 <p>L'apprendimento supervisionato è come avere un insegnante paziente che corregge costantemente i nostri errori. Gli algoritmi vengono addestrati su dataset etichettati, dove ogni input è associato all'output corretto desiderato. Questo approccio è alla base dei sistemi di raccomandazione di Netflix, degli algoritmi di riconoscimento facciale di Facebook e dei filtri antispam della nostra posta elettronica.</p>
-
 <p>Gli algoritmi più utilizzati includono:</p>
-
 <ul>
 <li><strong>Regressione Lineare</strong>: utilizzata per predire valori continui, come il prezzo di un immobile basandosi su caratteristiche come metratura, posizione e anno di costruzione</li>
 <li><strong>Alberi di Decisione</strong>: creano una serie di domande binarie per arrivare a una classificazione, come un questionario medico che porta a una diagnosi</li>
 <li><strong>Support Vector Machines (SVM)</strong>: trovano il confine ottimale tra diverse categorie di dati, particolarmente efficaci nella classificazione di testi e immagini</li>
 </ul>
-
 <h4>Apprendimento Non Supervisionato: L'Arte della Scoperta</h4>
-
 <p>Se l'apprendimento supervisionato è come studiare con un tutor, quello non supervisionato è come essere esploratori in un territorio sconosciuto. Gli algoritmi devono scoprire da soli i pattern nascosti nei dati, senza alcuna guida esterna.</p>
-
 <p>Il <strong>K-Means Clustering</strong>, ad esempio, può analizzare i comportamenti di acquisto dei clienti e identificare automaticamente gruppi con preferenze simili, permettendo alle aziende di personalizzare le loro strategie di marketing. La <strong>Principal Component Analysis (PCA)</strong> riduce la complessità dei dati mantenendo le informazioni più importanti, una tecnica fondamentale nell'analisi di big data.</p>
-
 <h4>Apprendimento per Rinforzo: Il Gioco dell'Esperienza</h4>
-
 <p>L'apprendimento per rinforzo è forse il più affascinante dei tre approcci. Come un bambino che impara a camminare attraverso tentativi ed errori, ricevendo "ricompense" (rimanere in piedi) o "punizioni" (cadere), gli algoritmi di rinforzo imparano attraverso l'interazione diretta con l'ambiente.</p>
-
 <p>Questo approccio ha portato ai trionfi dell'AI nei giochi: AlphaGo di DeepMind che ha battuto i campioni mondiali di Go, e più recentemente, sistemi che eccellono in videogiochi complessi come StarCraft II. Ma le applicazioni vanno ben oltre l'intrattenimento: dalla guida autonoma alla gestione del traffico urbano, fino all'ottimizzazione di portafogli finanziari.</p>
-
 <h2>Deep Learning: Quando l'Intelligenza Artificiale Imita il Cervello</h2>
-
 <h3>L'Architettura della Mente Artificiale</h3>
-
 <p>Il Deep Learning rappresenta un salto evolutivo nel Machine Learning, ispirandosi direttamente al funzionamento del cervello umano. Come i neuroni biologici si connettono in reti complesse per elaborare informazioni, le reti neurali artificiali utilizzano strati multipli di unità computazionali interconnesse.</p>
-
 <p>I recenti progressi nei transformer hanno rivoluzionato la comprensione del successo di queste architetture, portando a breakthrough significativi in diversi ambiti applicativi. Il 2025 ha già visto avanzamenti notevoli, con SAM 2 che permette ai computer di tracciare e identificare oggetti nei video, non solo nelle immagini statiche.</p>
-
 <h3>Le Reti Neurali Convoluzionali: Gli Occhi dell'AI</h3>
-
 <p>Le <strong>Reti Neurali Convoluzionali (CNN)</strong> hanno rivoluzionato il mondo della visione artificiale. Ispirate al funzionamento della corteccia visiva, queste reti utilizzano filtri che "scansionano" le immagini per identificare caratteristiche come bordi, texture e forme.</p>
-
 <p>Oggi, le CNN non si limitano più al riconoscimento di oggetti in foto statiche. Sono il motore dietro:</p>
-
 <ul>
 <li><strong>Diagnosi medica avanzata</strong>: sistemi che possono identificare tumori in radiografie con precisione superiore a quella di molti medici specializzati</li>
 <li><strong>Guida autonoma</strong>: elaborazione in tempo reale di milioni di pixel per riconoscere pedoni, veicoli, segnali stradali e ostacoli</li>
 <li><strong>Realtà aumentata</strong>: riconoscimento e tracking di oggetti del mondo reale per sovrapporre informazioni digitali</li>
 <li><strong>Controllo qualità industriale</strong>: ispezione automatica di prodotti manifatturieri con velocità e precisione impossibili per l'occhio umano</li>
 </ul>
-
 <h3>Le Reti Neurali Ricorrenti: La Memoria dell'AI</h3>
-
 <p>Mentre le CNN eccellono nell'elaborazione di dati spaziali, le <strong>Reti Neurali Ricorrenti (RNN)</strong> sono specializzate in sequenze temporali. Dotate di una forma di "memoria", possono ricordare informazioni precedenti per elaborare l'input corrente.</p>
-
 <p>Le varianti più avanzate includono:</p>
-
 <ul>
 <li><strong>LSTM (Long Short-Term Memory)</strong>: risolvono il problema del "gradiente che svanisce", permettendo alle reti di memorizzare informazioni per lunghi periodi</li>
 <li><strong>GRU (Gated Recurrent Unit)</strong>: una versione semplificata delle LSTM che mantiene prestazioni simili con minor complessità computazionale</li>
 </ul>
-
 <p>Le applicazioni delle RNN spaziano dalla traduzione automatica (come Google Translate) alla composizione musicale assistita, dalla previsione di serie temporali finanziarie alla generazione di codice di programmazione.</p>
-
 <h3>Transformer: L'Architettura che ha Cambiato Tutto</h3>
-
 <p>L'introduzione dei <strong>Transformer</strong> nel 2017 ha rappresentato una rivoluzione copernicana nel Deep Learning. Questi modelli hanno abbandonato la sequenzialità delle RNN in favore di un meccanismo di "attenzione" che permette di elaborare tutti gli elementi di una sequenza simultaneamente.</p>
-
 <p>Oggi esistono numerosi modi per adattare i modelli a casi d'uso specifici, incluse tecniche di fine-tuning e breakthrough più recenti come la Direct Preference Optimization (DPO), un algoritmo che può essere considerato un'alternativa al Reinforcement Learning with Human Feedback (RLHF).</p>
-
 <p>I Transformer sono alla base dei grandi modelli linguistici come GPT-4, Claude, e altri sistemi conversazionali che stanno trasformando il modo in cui interagiamo con la tecnologia.</p>
-
 <h2>Algoritmi Generativi: Quando l'AI Diventa Creativa</h2>
-
 <h3>La Nascita della Creatività Artificiale</h3>
-
 <p>Gli <strong>algoritmi generativi</strong> rappresentano forse l'aspetto più affascinante e controverso dell'AI moderna. Nel 2025, l'AI generativa si sta rapidamente trasformando da tecnologia promettente ad asset di valore, con aziende di tutto il mondo che la integrano nei loro processi produttivi.</p>
-
 <p>Questi sistemi non si limitano più a riconoscere o classificare: creano contenuti originali, dalle immagini alla musica, dal testo ai video, spesso indistinguibili da quelli prodotti dall'uomo.</p>
-
 <h3>GAN: La Competizione che Genera Perfezione</h3>
-
 <p>Le <strong>Reti Generative Avversariali (GAN)</strong>, introdotte da Ian Goodfellow nel 2014, funzionano attraverso un principio geniale: due reti neurali che competono tra loro in un gioco infinito.</p>
-
 <p>Il <strong>Generatore</strong> cerca di creare dati falsi così convincenti da ingannare il suo avversario, mentre il <strong>Discriminatore</strong> diventa sempre più bravo nel distinguere il vero dal falso. Questa competizione continua spinge entrambe le reti verso la perfezione, fino a quando il Generatore produce contenuti indistinguibili dalla realtà.</p>
-
 <p>Le applicazioni delle GAN oggi includono:</p>
-
 <ul>
 <li><strong>DeepFake</strong> per l'industria cinematografica: attori digitali che possono recitare scene senza essere fisicamente presenti</li>
 <li><strong>Fashion design</strong>: creazione automatica di nuovi capi di abbigliamento basati su tendenze e preferenze</li>
 <li><strong>Architettura</strong>: generazione di progetti edilizi ottimizzati per efficienza energetica e estetica</li>
 <li><strong>Gaming</strong>: creazione procedurali di mondi virtuali e personaggi</li>
 </ul>
-
 <h3>L'Esplosione dell'AI Generativa: Dal Testo alle Immagini</h3>
-
 <p>Il 2022 ha segnato un punto di svolta con il lancio di ChatGPT, ma il 2024 e il 2025 hanno visto un'accelerazione ancora più drammatica. L'influenza dell'AI generativa continua a semplificare i workflow, migliorare le operazioni e fornire nuovo valore per le aziende.</p>
-
 <p><strong>DALL-E, Midjourney e Stable Diffusion</strong> hanno democratizzato la creazione artistica, permettendo a chiunque di generare immagini professionali semplicemente descrivendo ciò che desidera. <strong>GPT-4 e i suoi successori</strong> possono scrivere codice, articoli, poesie e persino intere sceneggiature. <strong>Suno e Udio</strong> stanno rivoluzionando la composizione musicale.</p>
-
 <p>L'AI generativa sta sconvolgendo i motori di ricerca tradizionali come li conosciamo, aiutandoci a trovare rapidamente informazioni sui nostri telefoni. Questa trasformazione sta ridefinendo il modo in cui accediamo e interagiamo con le informazioni.</p>
-
 <h2>Le Sfide del Presente: Problemi da Risolvere</h2>
-
 <h3>Il Sovradattamento: Quando l'Intelligenza Diventa Rigidità</h3>
-
 <p>Uno dei problemi più insidiosi nel Machine Learning è il <strong>sovradattamento</strong> (overfitting). Come uno studente che memorizza le risposte invece di comprendere i concetti, un modello sovradattato ha prestazioni eccellenti sui dati di addestramento ma fallisce miseramente con nuove informazioni.</p>
-
 <p>Questo problema è particolarmente critico nell'era dei grandi modelli linguistici, dove la tentazione di ottimizzare le prestazioni su benchmark specifici può compromettere la capacità di generalizzazione.</p>
-
 <h3>Il Bias: Quando l'AI Eredita i Nostri Pregiudizi</h3>
-
 <p>I sistemi di AI non sono immuni dai pregiudizi umani. L'Intelligenza Artificiale Spiegabile sta diventando fondamentale per chiarire perché un modello arriva a determinati risultati, affrontando le crescenti preoccupazioni su trasparenza e equità.</p>
-
 <p>Un esempio emblematico: sistemi di selezione del personale che discriminano candidati femminili perché addestrati su dati storici di aziende che assumevano prevalentemente uomini. O algoritmi di riconoscimento facciale che funzionano meglio su persone di etnia caucasica perché i dataset di addestramento erano sbilanciati.</p>
-
 <h3>La Complessità Computazionale: Il Costo dell'Intelligenza</h3>
-
 <p>Il Deep Learning e gli algoritmi generativi richiedono enormi risorse computazionali. GPT-4 ha richiesto mesi di addestramento su migliaia di GPU, con costi stimati in decine di milioni di dollari. Questa barriera economica e ambientale (per il consumo energetico) limita l'accesso a queste tecnologie.</p>
-
 <h3>L'Interpretabilità: La Scatola Nera dell'AI</h3>
-
 <p>I modelli di Deep Learning sono spesso "scatole nere": anche i loro creatori faticano a spiegare perché prendono certe decisioni. Questo è problematico in settori critici come la medicina o la giustizia, dove la trasparenza è fondamentale.</p>
-
 <h2>Lo Stato dell'Arte nel 2025: Dove Siamo Oggi</h2>
-
 <h3>Breakthrough Recenti e Tendenze Emergenti</h3>
-
 <p>I cinque paper breakthrough dell'inizio 2025 mostrano come il machine learning continui ad avanzare in diverse aree, con particolare attenzione a:</p>
-
 <ol>
 <li><strong>Computer Vision Avanzata</strong>: sistemi che non solo identificano oggetti ma comprendono le relazioni spaziali e temporali</li>
 <li><strong>Natural Language Processing</strong>: modelli che stanno avvicinandosi alla comprensione umana del linguaggio</li>
 <li><strong>Multimodalità</strong>: AI che può elaborare simultaneamente testo, immagini, audio e video</li>
 <li><strong>Efficienza Computazionale</strong>: architetture ottimizzate che richiedono meno risorse</li>
 </ol>
-
 <h3>L'Integrazione nell'Ecosistema Tecnologico</h3>
-
 <p>Il 77% delle aziende si aspetta il maggiore impatto dall'AI Generativa tra le tecnologie emergenti, mentre oltre il 60% dei rispondenti la vede come un'opportunità per ottenere un vantaggio competitivo.</p>
-
 <p>Settori specifici stanno vedendo trasformazioni particolarmente significative:</p>
-
 <p><strong>Sanità</strong>: AI che può analizzare scan medici, predire epidemie e accelerare la scoperta di farmaci
 <strong>Finanza</strong>: algoritmi che rilevano frodi in tempo reale e ottimizzano strategie di investimento
 <strong>Educazione</strong>: tutor AI personalizzati che si adattano al ritmo di apprendimento di ogni studente
 <strong>Intrattenimento</strong>: generazione procedurale di contenuti per giochi e film
 <strong>Trasporti</strong>: veicoli autonomi che stanno passando dai test alle implementazioni commerciali</p>
-
 <h3>Le Grandi Aziende e la Corsa all'AI</h3>
-
 <p>Il 2024 e il 2025 hanno visto una corsa senza precedenti tra i giganti tecnologici:</p>
-
 <ul>
 <li><strong>OpenAI</strong> continua a dominare l'AI generativa con GPT-4 e i suoi successori</li>
 <li><strong>Google</strong> ha risposto con Gemini 2.0, un modello AI all'avanguardia con capacità agentiche progettato per sviluppatori, aziende e privati</li>
@@ -333,53 +264,33 @@
 <li><strong>Meta</strong> ha democratizzato l'accesso con modelli open-source come Llama</li>
 <li><strong>Microsoft</strong> ha integrato l'AI in tutto il suo ecosistema, da Office a Windows</li>
 </ul>
-
 <h2>Il Futuro che ci Aspetta: Previsioni e Sviluppi</h2>
-
 <h3>Towards AGI: Verso l'Intelligenza Artificiale Generale</h3>
-
 <p>Molti esperti credono che siamo sulla soglia dell'<strong>Intelligenza Artificiale Generale (AGI)</strong> - sistemi AI che eguagliano o superano l'intelligenza umana in tutti i domini cognitivi. Mentre le stime variano dal 2030 al 2050, i progressi attuali suggeriscono che questo traguardo potrebbe essere più vicino di quanto pensiamo.</p>
-
 <h3>Tecnologie Emergenti da Tenere d'Occhio</h3>
-
 <p><strong>Quantum Machine Learning</strong>: l'integrazione tra computer quantistici e AI potrebbe risolvere problemi attualmente intrattabili</p>
-
 <p><strong>Neuromorphic Computing</strong>: chip che imitano più fedelmente il funzionamento del cervello umano, promettendo maggiore efficienza energetica</p>
-
 <p><strong>Federated Learning</strong>: sistemi che imparano senza centralizzare i dati, preservando la privacy</p>
-
 <p><strong>Self-Supervised Learning</strong>: AI che impara principalmente da dati non etichettati, riducendo la dipendenza da dataset curati manualmente</p>
-
 <h3>Implicazioni Sociali ed Economiche</h3>
-
 <p>La rivoluzione dell'AI avrà impatti profondi su:</p>
-
 <p><strong>Lavoro</strong>: automazione di professioni cognitive, necessità di riqualificazione massiva
 <strong>Educazione</strong>: personalizzazione dell'apprendimento, obsolescenza di alcuni metodi tradizionali
 <strong>Creatività</strong>: collaborazione uomo-macchina in arte, design e contenuti
 <strong>Decisioni</strong>: supporto AI in medicina, giustizia e policy pubbliche
 <strong>Privacy</strong>: nuove sfide nella protezione dei dati personali</p>
-
 <h2>Verso un'AI Responsabile: Le Considerazioni Etiche</h2>
-
 <h3>La Necessità di Governance</h3>
-
 <p>Man mano che l'AI diventa più potente e pervasiva, cresce l'urgenza di stabilire framework etici e normativi. L'Unione Europea ha fatto da pioniera con l'AI Act, mentre altri paesi stanno sviluppando le proprie regolamentazioni.</p>
-
 <h3>Principi per un'AI Benefica</h3>
-
 <p>Gli esperti concordano su alcuni principi fondamentali:</p>
-
 <p><strong>Trasparenza</strong>: i sistemi AI devono essere comprensibili e verificabili
 <strong>Equità</strong>: prevenzione e correzione dei bias discriminatori
 <strong>Privacy</strong>: protezione dei dati personali e del diritto all'oblio
 <strong>Sicurezza</strong>: sistemi robusti e affidabili, specialmente in applicazioni critiche
 <strong>Controllo Umano</strong>: mantenimento del controllo umano su decisioni importanti</p>
-
 <h3>Il Ruolo della Società Civile</h3>
-
 <p>L'evoluzione dell'AI non può essere lasciata solo a tecnici e aziende. È necessario un dialogo inclusivo che coinvolga:</p>
-
 <ul>
 <li>Educatori e studenti</li>
 <li>Lavoratori e sindacati  </li>
@@ -387,40 +298,26 @@
 <li>Gruppi per i diritti civili</li>
 <li>Rappresentanti delle comunità più vulnerabili</li>
 </ul>
-
 <h2>Preparare il Futuro: Cosa Possiamo Fare Oggi</h2>
-
 <h3>Per i Professionisti</h3>
-
 <p><strong>Aggiornamento Continuo</strong>: il campo evolve rapidamente, è essenziale rimanere informati
 <strong>Competenze Trasversali</strong>: combinare expertise tecnica con comprensione etica e sociale
 <strong>Collaborazione Interdisciplinare</strong>: lavorare con esperti di altri domini</p>
-
 <h3>Per le Organizzazioni</h3>
-
 <p><strong>Strategia AI</strong>: sviluppare piani chiari per l'integrazione dell'AI
-<strong>Formazione del Personale</strong>: investire nella riqualificazione dei dipendenti<br />
+<strong>Formazione del Personale</strong>: investire nella riqualificazione dei dipendenti<br/>
 <strong>Etica by Design</strong>: incorporare considerazioni etiche fin dall'inizio dei progetti
 <strong>Governance</strong>: stabilire comitati e processi per supervisionare l'uso dell'AI</p>
-
 <h3>Per la Società</h3>
-
 <p><strong>Alfabetizzazione AI</strong>: educare il pubblico sui fondamenti e le implicazioni dell'AI
 <strong>Partecipazione Democratica</strong>: coinvolgimento attivo nei dibattiti su regolamentazione e governance
 <strong>Vigilanza Critica</strong>: monitoraggio degli impatti sociali e ambientali dell'AI</p>
-
 <h2>Conclusioni: L'AI come Amplificatore Umano</h2>
-
 <p>Il Machine Learning, il Deep Learning e gli algoritmi generativi non sono solo innovazioni tecniche: rappresentano un'estensione delle capacità cognitive umane. Come la scrittura ha amplificato la nostra memoria e la stampa ha democratizzato la conoscenza, l'AI sta amplificando la nostra intelligenza.</p>
-
 <p>Nonostante i progressi rapidissimi, meno della metà degli americani tra i 18 e i 64 anni usa l'AI generativa, e poco più di un quarto la usa al lavoro. Questo gap tra potenziale e adozione rappresenta sia una sfida che un'opportunità.</p>
-
 <p>Il futuro dell'AI non è predeterminato. Le scelte che facciamo oggi - come ricercatori, sviluppatori, policymaker e cittadini - determineranno se questa tecnologia amplifica il meglio dell'umanità o ne esacerba i problemi esistenti.</p>
-
 <p>Mentre navighiamo questa trasformazione epocale, dobbiamo ricordare che l'obiettivo finale non è creare macchine che ci sostituiscano, ma sviluppare strumenti che ci permettano di essere più creativi, più efficaci e più umani. In questa visione, l'Intelligenza Artificiale non è il futuro dell'umanità, ma uno strumento per costruire un futuro più luminoso per tutti.</p>
-
 <p>Il viaggio è appena iniziato, e ognuno di noi ha un ruolo da svolgere nel plasmare questa nuova era dell'intelligenza ibrida uomo-macchina. Come la rivoluzione industriale ha richiesto generazioni per essere pienamente compresa e integrata, la rivoluzione dell'AI richiederà saggezza, pazienza e collaborazione per realizzare il suo pieno potenziale benefico.</p>
-
 <p>L'intelligenza artificiale del 2025 non è più fantascienza: è realtà quotidiana che sta riscrivendo le regole del possibile. Sta a noi assicurarci che questa riscrittura porti a un finale migliore per tutti.</p>
 
             <div class="footer-back-button">

--- a/dist/03-Dalle Applicazioni Consolidate alle Frontiere del Futuro.html
+++ b/dist/03-Dalle Applicazioni Consolidate alle Frontiere del Futuro.html
@@ -162,50 +162,28 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>L'Intelligenza Artificiale Oggi: Dalle Applicazioni Consolidate alle Frontiere del Futuro</h1>
-
 <p>di <em>Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="fotocopertina2.jpg" alt="fotocopertina2.jpg" /></p>
-
+<img alt="fotocopertina2.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/03-Dalle Applicazioni Consolidate alle Frontiere del Futuro/fotocopertina2.jpg"/></p>
 <p><em>Dopo aver esplorato i fondamenti teorici e storici dell'intelligenza artificiale nei primi due articoli della nostra serie, è giunto il momento di immergerci nel cuore pulsante di questa rivoluzione tecnologica: le sue applicazioni concrete nel mondo reale. Se negli anni passati l'AI sembrava confinata nei laboratori di ricerca e nei film di fantascienza, oggi è diventata una presenza costante e spesso invisibile nella nostra vita quotidiana, trasformando settori che vanno dalla medicina all'intrattenimento, dalla finanza alla robotica.</em></p>
-
 <h2>Il Gaming: Dove l'AI Ha Mosso i Primi Passi da Gigante</h2>
-
 <p>Il mondo dei giochi rappresenta uno dei campi di battaglia più affascinanti dell'intelligenza artificiale. Non è un caso che molte delle vittorie più eclatanti dell'AI siano avvenute proprio qui, su scacchiere reali e virtuali che hanno catturato l'immaginazione del pubblico mondiale.</p>
-
 <h3>La Rivoluzione degli Scacchi e Oltre</h3>
-
 <p>La storia dell'AI nel gaming inizia con gli scacchi. Mentre Deep Blue di IBM ha segnato la prima vittoria storica contro un campione mondiale nel 1997, i programmi moderni come <strong>Stockfish</strong> e <strong>Komodo</strong> hanno raggiunto livelli di gioco che superano qualsiasi umano. Questi sistemi possono valutare milioni di posizioni al secondo, utilizzando algoritmi di ricerca avanzati combinati con valutazioni euristiche raffinate da decenni di sviluppo.</p>
-
 <p>Ma la vera rivoluzione è arrivata con <strong>AlphaGo</strong> di DeepMind nel 2016. Il Go, un gioco millenario cinese con un numero di possibili configurazioni superiore agli atomi nell'universo osservabile, era considerato l'ultima frontiera dell'AI nei giochi da tavolo. La vittoria di AlphaGo contro Lee Sedol non è stata solo una dimostrazione di potenza computazionale, ma ha mostrato per la prima volta una forma di "intuizione" artificiale, con mosse che inizialmente sembravano errori ma si rivelavano brillanti strategie a lungo termine.</p>
-
 <h3>L'AI nei Videogiochi Moderni</h3>
-
 <p>Nel 2025, l'intelligenza artificiale nei videogiochi ha fatto passi da gigante. Gli esperimenti recenti con simulazioni 3D generative stanno aprendo la strada a tipi di giochi completamente nuovi, dove è possibile trasformare un semplice schizzo in un ambiente giocabile in tempo reale. Questa evoluzione va ben oltre i tradizionali NPC (personaggi non giocanti) che reagiscono alle azioni del giocatore.</p>
-
 <p>I moderni sistemi di AI nei videogiochi utilizzano tecniche di apprendimento automatico per creare esperienze dinamiche e personalizzate. Gli NPC non si limitano più a seguire script predefiniti, ma apprendono dalle strategie dei giocatori, adattando il proprio comportamento per offrire sfide sempre nuove e bilanciate. La generazione procedurale di contenuti, supportata dall'AI, permette di creare mondi aperti, missioni e persino trame che si evolvono in base alle scelte del giocatore.</p>
-
 <h2>L'Elaborazione del Linguaggio Naturale: Quando le Macchine Imparano a Parlare</h2>
-
 <p>Se c'è un campo dove l'AI ha mostrato progressi spettacolari negli ultimi anni, è certamente l'elaborazione del linguaggio naturale (NLP). La capacità delle macchine di comprendere, interpretare e generare linguaggio umano ha raggiunto livelli che fino a pochi anni fa sembravano fantascientifici.</p>
-
 <h3>La Rivoluzione della Traduzione Automatica</h3>
-
 <p>Google Translate, lanciato nel 2006, ha compiuto un salto quantico con l'introduzione delle reti neurali nel 2016. Oggi, la traduzione automatica non si limita più a sostituire parole in modo meccanico, ma comprende il contesto, le sfumature culturali e persino l'umore del testo. I modelli più avanzati possono tradurre non solo testo scritto, ma anche conversazioni in tempo reale, supportando centinaia di lingue e dialetti.</p>
-
 <p>La tecnologia di traduzione neurale ha reso possibile la comunicazione istantanea tra persone che parlano lingue diverse, abbattendo barriere linguistiche che hanno diviso l'umanità per millenni. Dalle app per viaggiatori agli strumenti professionali per interpreti, la traduzione automatica è diventata un ponte universale tra culture diverse.</p>
-
 <h3>Gli Assistenti Virtuali: I Nostri Compagni Digitali</h3>
-
 <p>Siri, Alexa, Google Assistant e i loro numerosi "colleghi" hanno trasformato il modo in cui interagiamo con la tecnologia. Questi assistenti virtuali combinano riconoscimento vocale, elaborazione del linguaggio naturale e apprendimento automatico per offrire un'interfaccia conversazionale intuitiva.</p>
-
 <p>L'evoluzione di questi sistemi è stata costante: dalle semplici ricerche vocali degli inizi, oggi possono gestire conversazioni complesse, controllare ecosistemi domestici intelligenti, programmare appuntamenti, effettuare acquisti online e persino fornire supporto emotivo di base. La loro integrazione in dispositivi sempre più vari – dai telefoni agli elettrodomestici, dalle auto ai dispositivi indossabili – li ha resi compagni digitali onnipresenti.</p>
-
 <h3>La Generazione di Testo Intelligente</h3>
-
 <p>L'arrivo di ChatGPT alla fine del 2022 ha segnato un momento di svolta nella percezione pubblica dell'AI. Nel panorama attuale del 2025, modelli come Claude 4 stanno dimostrando prestazioni superiori nella generazione di codice, raggiungendo accuratezze del 62-70% in benchmark che simulano compiti di programmazione del mondo reale.</p>
-
 <p>I Large Language Models (LLM) di oggi non si limitano a generare testo coerente, ma possono:</p>
-
 <ul>
 <li>Scrivere codice di programmazione in decine di linguaggi</li>
 <li>Creare contenuti creativi come poesie, racconti e sceneggiature  </li>
@@ -213,21 +191,13 @@
 <li>Fornire spiegazioni tecniche adatte a diversi livelli di competenza</li>
 <li>Tradurre non solo tra lingue diverse, ma anche tra stili di comunicazione</li>
 </ul>
-
 <p>Il futuro dell'AI si sta sempre più orientando verso modelli multimodali, come il text-to-video Sora di OpenAI e i generatori vocali di ElevenLabs, capaci di gestire dati non testuali come audio, video e immagini.</p>
-
 <h2>Sistemi Esperti: L'Intelligenza Artificiale al Servizio delle Decisioni Critiche</h2>
-
 <p>I sistemi esperti rappresentano una delle applicazioni più mature e strategiche dell'intelligenza artificiale, particolarmente nei settori dove le decisioni hanno conseguenze critiche sulla vita umana e sui processi economici.</p>
-
 <h3>Diagnostica Medica: Quando l'AI Salva Vite</h3>
-
 <p>Nel campo medico, l'AI ha dimostrato capacità diagnostiche che in alcuni casi superano quelle dei medici umani. I sistemi di imaging medicale basati su AI possono identificare tumori in radiografie, risonanze magnetiche e TAC con una precisione superiore al 95%, spesso rilevando anomalie che sfuggono all'occhio umano.</p>
-
 <p>Robot come Moxi, prodotto da Diligent Robotics, rappresentano una nuova generazione di assistenti sanitari. Questo robot alto 1,2 metri supporta il personale infermieristico negli ospedali svolgendo compiti come la consegna di forniture ai pazienti e il prelievo di campioni di laboratorio, utilizzando sensori e tecnologie AI per navigare negli ambienti clinici.</p>
-
 <p>I sistemi diagnostici AI moderni non si limitano alla semplice identificazione di patologie, ma possono:</p>
-
 <ul>
 <li>Prevedere l'evoluzione di malattie croniche</li>
 <li>Suggerire protocolli terapeutici personalizzati</li>
@@ -235,17 +205,11 @@
 <li>Identificare interazioni farmacologiche pericolose</li>
 <li>Ottimizzare la distribuzione delle risorse ospedaliere</li>
 </ul>
-
 <p>Un esempio particolarmente impressionante è rappresentato dai sistemi di AI per la diagnosi oculistica, che possono identificare retinopatia diabetica e glaucoma attraverso semplici fotografie del fondo oculare, rendendo possibile lo screening di massa in aree del mondo dove l'accesso agli specialisti è limitato.</p>
-
 <h3>Supporto Decisionale: L'AI nella Finanza e nella Logistica</h3>
-
 <p>Nel settore finanziario, gli algoritmi di trading automatico processano migliaia di transazioni al secondo, analizzando pattern di mercato complessi e prendendo decisioni di investimento in millisecondi. Questi sistemi non solo reagiscono ai movimenti di mercato, ma possono anticipare trend basandosi su analisi di sentiment dei social media, notizie economiche e indicatori macroeconomici.</p>
-
 <p>Nel 2025, la domanda di chip specializzati (ASIC) potrebbe accelerare con l'aumento dell'adozione dell'AI edge su dispositivi più piccoli, mentre le aziende cercano approcci meno prescrittivi per le loro infrastrutture di data center.</p>
-
 <p>La logistica moderna è impensabile senza AI. Amazon, UPS, DHL e altre aziende utilizzano algoritmi avanzati per:</p>
-
 <ul>
 <li>Ottimizzare le rotte di consegna in tempo reale</li>
 <li>Prevedere la domanda e gestire le scorte</li>
@@ -253,17 +217,11 @@
 <li>Coordinare flotte di veicoli autonomi</li>
 <li>Ridurre sprechi e impatti ambientali</li>
 </ul>
-
 <h2>Visione Artificiale: Gli Occhi Digitali del Futuro</h2>
-
 <p>La capacità delle macchine di "vedere" e interpretare il mondo visivo ha raggiunto livelli straordinari, aprendo possibilità applicative che vanno dalla sicurezza pubblica alla medicina, dall'automotive all'intrattenimento.</p>
-
 <h3>Riconoscimento di Immagini: Precisione Oltre l'Umano</h3>
-
 <p>I sistemi moderni di computer vision possono identificare e classificare oggetti, volti, scene e attività con una precisione che spesso supera quella umana. Le Reti Neurali Convoluzionali (CNN) hanno rivoluzionato questo campo, permettendo alle macchine di riconoscere pattern visivi complessi in modo gerarchico, proprio come fa il cervello umano.</p>
-
 <p>Le applicazioni pratiche sono innumerevoli:</p>
-
 <ul>
 <li><strong>Sicurezza aeroportuale</strong>: Scanner che identificano oggetti pericolosi nei bagagli</li>
 <li><strong>Agricoltura di precisione</strong>: Droni che monitorano la salute delle colture</li>
@@ -271,15 +229,10 @@
 <li><strong>Medicina</strong>: Analisi automatica di biopsie e imaging diagnostico</li>
 <li><strong>Retail</strong>: Checkout automatici senza cassieri</li>
 </ul>
-
 <h3>Guida Autonoma: La Strada Verso il Futuro</h3>
-
 <p>Le automobili a guida autonoma rappresentano una delle frontiere più ambiziose dell'AI. Aziende come Tesla, Waymo, Cruise e decine di startup stanno sviluppando sistemi che promettono di rivoluzionare il trasporto urbano e extraurbano.</p>
-
 <p>Nonostante i progressi, gli esperti rimangono cauti sui tempi di diffusione su larga scala. Anche se aziende come Tesla con Optimus e 1X con Neo stanno sviluppando robot umanoidi, è improbabile che siano ampiamente disponibili ai consumatori nel 2025, poiché questi robot sono ancora nelle prime fasi di sviluppo.</p>
-
 <p>I veicoli autonomi utilizzano una combinazione di tecnologie:</p>
-
 <ul>
 <li><strong>LiDAR</strong>: Per creare mappe 3D dell'ambiente circostante</li>
 <li><strong>Telecamere</strong>: Per riconoscere segnali stradali, pedoni e altri veicoli</li>
@@ -287,397 +240,249 @@
 <li><strong>GPS avanzato</strong>: Per la localizzazione precisa</li>
 <li><strong>AI per la fusione dei sensori</strong>: Per integrare tutti i dati in tempo reale</li>
 </ul>
-
 <p>Le sfide tecniche sono enormi: prevedere il comportamento umano imprevedibile, gestire condizioni meteorologiche avverse, navigare in contesti urbani complessi e garantire la sicurezza in tutte le circostanze.</p>
-
 <h2>Riconoscimento Biometrico: Identità nell'Era Digitale</h2>
-
 <h3>Riconoscimento Facciale: Comodità e Controversie</h3>
-
 <p>Il riconoscimento facciale è diventato ubiquo: dalle fotocamere degli smartphone alle telecamere di sorveglianza urbana, dai controlli aeroportuali ai pagamenti digitali. La tecnologia Face ID di Apple ha democratizzato l'uso della biometria facciale, mentre sistemi più avanzati vengono utilizzati per la sicurezza pubblica e la prevenzione crimini.</p>
-
 <p>Tuttavia, questa tecnologia solleva questioni etiche significative:</p>
-
 <ul>
 <li><strong>Privacy</strong>: Chi controlla i dati biometrici raccolti?</li>
 <li><strong>Bias algoritmici</strong>: Alcuni sistemi mostrano precisione diversa per diverse etnie</li>
 <li><strong>Sorveglianza di massa</strong>: Il rischio di società iper-controllate</li>
 <li><strong>Consenso</strong>: Molti sistemi operano senza consenso esplicito degli utenti</li>
 </ul>
-
 <h3>Riconoscimento Vocale: La Voce Come Chiave</h3>
-
 <p>Il riconoscimento vocale non serve solo per i comandi agli assistenti virtuali. Sistemi avanzati possono identificare individui specifici attraverso caratteristiche uniche della voce, utilizzati per:</p>
-
 <ul>
 <li><strong>Autenticazione bancaria telefonica</strong></li>
 <li><strong>Sistemi di sicurezza aziendale</strong></li>
 <li><strong>Controllo accessi in ambienti sensibili</strong></li>
 <li><strong>Trascrizione automatica di riunioni e conferenze</strong></li>
 </ul>
-
 <p>La tecnologia ha raggiunto livelli di accuratezza superiori al 95% anche in ambienti rumorosi, supportando centinaia di lingue e accenti regionali.</p>
-
 <h2>Robotica Intelligente: Verso un Mondo di Collaborazione Uomo-Macchina</h2>
-
 <p>La robotica moderna non riguarda più solo l'automazione industriale, ma sta evolvendo verso robot intelligenti capaci di collaborare con gli esseri umani in ambienti complessi e non strutturati.</p>
-
 <h3>Robotica Industriale 4.0</h3>
-
 <p>La quarta rivoluzione industriale vede robot che non si limitano a ripetere compiti programmati, ma possono:</p>
-
 <ul>
 <li><strong>Adattarsi a variazioni</strong>: Modificare il comportamento in base ai cambiamenti nell'ambiente di lavoro</li>
 <li><strong>Collaborare con umani</strong>: Lavorare fianco a fianco con operatori umani in sicurezza</li>
 <li><strong>Apprendere continuamente</strong>: Migliorare le prestazioni attraverso l'esperienza</li>
 <li><strong>Comunicare</strong>: Interfacciarsi con altri sistemi e operatori attraverso linguaggio naturale</li>
 </ul>
-
 <p>I robot collaborativi (cobots) stanno trasformando settori come automotive, elettronica, farmaceutico e alimentare, dove la precisione e la consistenza sono critiche.</p>
-
 <h3>Robotica di Servizio: Robot per la Vita Quotidiana</h3>
-
 <p>I robot di servizio stanno lentamente entrando nelle nostre case e comunità:</p>
-
 <ul>
 <li><strong>Robot domestici</strong>: Aspirapolvere intelligenti, robot da cucina, assistenti per anziani</li>
 <li><strong>Robot commerciali</strong>: Addetti alle pulizie, guide museali, camerieri in ristoranti</li>
 <li><strong>Robot sanitari</strong>: Assistenti per disabili, compagni per terapie pediatriche</li>
 <li><strong>Robot di consegna</strong>: Droni e robot terrestri per il delivery</li>
 </ul>
-
 <h3>Robotica Militare e di Soccorso</h3>
-
 <p>In ambiti critici, i robot intelligenti stanno salvando vite umane:</p>
-
 <ul>
 <li><strong>Robot da soccorso</strong>: Per interventi in disastri naturali e ambienti pericolosi</li>
 <li><strong>Robot militari</strong>: Per missioni di ricognizione e sminamento</li>
 <li><strong>Robot subacquei</strong>: Per esplorazioni marine e riparazioni offshore</li>
 <li><strong>Robot spaziali</strong>: Per missioni di esplorazione e manutenzione satellitare</li>
 </ul>
-
 <h2>Applicazioni Emergenti: Le Frontiere del 2025</h2>
-
 <h3>AI nella Creatività: Quando le Macchine Diventano Artiste</h3>
-
 <p>L'intelligenza artificiale sta sfidando la nozione tradizionale di creatività umana. Strumenti come DALL-E, Midjourney, Stable Diffusion per le immagini, e Suno, Udio per la musica, permettono a chiunque di creare contenuti di qualità professionale attraverso semplici descrizioni testuali.</p>
-
 <p>Nel 2025, assistiamo a:</p>
-
 <ul>
 <li><strong>AI generativa per il cinema</strong>: Creazione di effetti speciali, doppiaggio in lingue diverse, persino attori virtuali</li>
 <li><strong>Design automatizzato</strong>: Dalla grafica ai loghi, dall'architettura al design industriale</li>
 <li><strong>Composizione musicale</strong>: Colonne sonore personalizzate, remix automatici, nuovi generi musicali</li>
 <li><strong>Scrittura creativa</strong>: Collaborazione tra autori umani e AI per romanzi, sceneggiature, poesie</li>
 </ul>
-
 <h3>AI nella Finanza: Oltre il Trading Algoritmico</h3>
-
 <p>Nel 2025, il 94% dei leader AI e dati conferma che l'interesse per l'AI sta portando a un maggiore focus sui dati, particolarmente nell'ambito dell'AI generativa. Il settore finanziario sta vedendo applicazioni innovative:</p>
-
 <ul>
 <li><strong>Analisi del credito personalizzata</strong>: Valutazione del rischio basata su migliaia di variabili</li>
 <li><strong>Prevenzione frodi in tempo reale</strong>: Identificazione di transazioni sospette in millisecondi  </li>
 <li><strong>Consulenza finanziaria automatizzata</strong>: Robo-advisor che gestiscono portafogli personalizzati</li>
 <li><strong>Assicurazioni dinamiche</strong>: Premi che si adattano in tempo reale al comportamento dell'assicurato</li>
 </ul>
-
 <h3>AI nella Salute Mentale: Supporto Psicologico Accessibile</h3>
-
 <p>Una delle applicazioni più promettenti dell'AI riguarda il supporto alla salute mentale:</p>
-
 <ul>
 <li><strong>Chatbot terapeutici</strong>: Disponibili 24/7 per supporto immediato</li>
 <li><strong>Monitoraggio dell'umore</strong>: Analisi di pattern vocali, testuali e comportamentali</li>
 <li><strong>Terapia personalizzata</strong>: Programmi adattati ai bisogni individuali</li>
 <li><strong>Rilevazione precoce</strong>: Identificazione di segnali di stress, depressione, disturbi alimentari</li>
 </ul>
-
 <h3>AI nel Settore Pubblico e Governance</h3>
-
 <p>Nel 2025, l'AI è destinata a diventare una pietra angolare delle operazioni del settore pubblico, trasformando il modo in cui le agenzie prendono decisioni e servono i cittadini. Guidando con l'innovazione basata sull'AI, le agenzie governative possono migliorare l'efficienza, migliorare il processo decisionale e fornire servizi migliori ai cittadini.</p>
-
 <p>Le applicazioni includono:</p>
-
 <ul>
 <li><strong>Servizi pubblici intelligenti</strong>: Chatbot per informazioni cittadini, permessi automatizzati</li>
 <li><strong>Gestione del traffico</strong>: Ottimizzazione semafori, prevenzione ingorghi</li>
 <li><strong>Pianificazione urbana</strong>: Analisi predittiva per sviluppo città sostenibili  </li>
 <li><strong>Sicurezza pubblica</strong>: Previsione crimini, ottimizzazione pattugliamenti</li>
 </ul>
-
 <h2>Sfide e Considerazioni Etiche</h2>
-
 <h3>Il Problema del Bias Algoritmico</h3>
-
 <p>Uno dei problemi più critici dell'AI moderna è il bias (pregiudizio) presente nei dati di training. Se i dati utilizzati per addestrare un sistema di AI contengono pregiudizi umani, l'algoritmo li replicherà e amplifierà. Questo ha portato a:</p>
-
 <ul>
 <li>Sistemi di riconoscimento facciale meno accurati per alcune etnie</li>
 <li>Algoritmi di assunzione che discriminano contro donne o minoranze</li>
 <li>Sistemi di credito che penalizzano certi gruppi demografici</li>
 <li>Chatbot che riproducono stereotipi sociali</li>
 </ul>
-
 <h3>Privacy e Sorveglianza</h3>
-
 <p>L'AI ha reso possibile livelli di sorveglianza precedentemente impensabili. La capacità di analizzare enormi quantità di dati personali solleva questioni fondamentali:</p>
-
 <ul>
 <li>Chi ha accesso ai nostri dati?</li>
 <li>Come vengono utilizzati?</li>
 <li>Possiamo controllare o cancellare le informazioni su di noi?</li>
 <li>Qual è il bilanciamento tra sicurezza e privacy?</li>
 </ul>
-
 <h3>Impatto sul Lavoro</h3>
-
 <p>L'automazione guidata dall'AI sta trasformando il mercato del lavoro:</p>
-
 <ul>
 <li><strong>Lavori a rischio</strong>: Molte professioni potrebbero essere automatizzate</li>
 <li><strong>Nuove opportunità</strong>: Emergono ruoli legati alla gestione e supervisione dell'AI</li>
 <li><strong>Riqualificazione</strong>: Necessità di formare lavoratori per nuove competenze</li>
 <li><strong>Disuguaglianze</strong>: Rischio di ampliare il divario tra lavoratori qualificati e non qualificati</li>
 </ul>
-
 <h3>Governance dell'AI</h3>
-
 <p>Nel 2025, i leader aziendali non avranno più il lusso di affrontare la governance dell'AI in modo inconsistente o solo in alcune parti del business. Man mano che l'AI diventa intrinseca alle operazioni e alle offerte di mercato, le aziende avranno bisogno di approcci sistematici e trasparenti.</p>
-
 <p>La necessità di regolamentazione è urgente:</p>
-
 <ul>
 <li><strong>Standard internazionali</strong>: Accordi globali su sicurezza e etica dell'AI</li>
 <li><strong>Trasparenza algoritmica</strong>: Diritto a comprendere come funzionano i sistemi che ci riguardano</li>
 <li><strong>Responsabilità</strong>: Chi è responsabile quando un sistema AI causa danni?</li>
 <li><strong>Testing e certificazione</strong>: Procedure per validare la sicurezza dei sistemi AI</li>
 </ul>
-
 <h2>Tendenze Future: Cosa Ci Aspetta</h2>
-
 <h3>Modelli Multimodali e AI Generalista</h3>
-
 <p>Una delle più grandi evoluzioni del prossimo anno può essere riassunta in due parole: testing e personalizzazione. Se puoi misurare rischi e minacce, puoi aiutare ad affrontarli o mitigarli.</p>
-
 <p>Il futuro dell'AI sembra orientato verso sistemi sempre più generalisti:</p>
-
 <ul>
 <li><strong>Modelli multimodali</strong>: Capaci di processare simultaneamente testo, immagini, audio, video</li>
 <li><strong>AI embodied ("incarnata")</strong>: Sistemi che possono interagire fisicamente con il mondo</li>
 <li><strong>Reasoning avanzato</strong>: I nuovi modelli Claude Opus 4 e Claude Sonnet 4 possono analizzare grandi dataset, eseguire compiti a lungo termine e intraprendere azioni complesse, con particolare efficacia nei compiti di programmazione</li>
 <li><strong>Agenti autonomi</strong>: AI capaci di completare compiti complessi con supervisione minima</li>
 </ul>
-
 <h3>Edge AI e Democratizzazione</h3>
-
 <p>L'AI sta migrando dal cloud ai dispositivi locali:</p>
-
 <ul>
 <li><strong>Smartphone più intelligenti</strong>: Elaborazione AI locale per privacy e velocità</li>
 <li><strong>IoT intelligente</strong>: Elettrodomestici e sensori con capacità AI integrate</li>
 <li><strong>Veicoli autonomi</strong>: Elaborazione in tempo reale senza dipendenza dalla connettività</li>
 <li><strong>Wearables avanzati</strong>: Dispositivi indossabili con AI per salute e fitness</li>
 </ul>
-
 <h3>Sostenibilità e Green AI</h3>
-
 <p>La crescente attenzione all'impatto ambientale dell'AI sta guidando innovazioni:</p>
-
 <ul>
 <li><strong>Algoritmi più efficienti</strong>: Riduzione del consumo energetico per training e inference</li>
 <li><strong>Hardware specializzato</strong>: Chip progettati specificamente per AI con minor consumo</li>
 <li><strong>Modelli federati</strong>: Training distribuito che riduce il trasferimento dati</li>
 <li><strong>AI per sostenibilità</strong>: Utilizzo dell'AI per ottimizzare consumi energetici e ridurre sprechi</li>
 </ul>
-
 <h2>L'AI nella Ricerca Scientifica</h2>
-
 <p>Una delle applicazioni più promettenti dell'intelligenza artificiale riguarda l'accelerazione della ricerca scientifica. L'AI sta trasformando il modo in cui conduciamo esperimenti, analizziamo dati e facciamo scoperte:</p>
-
 <h3>Scoperta di Farmaci</h3>
-
 <p>L'AI può analizzare milioni di composti chimici per identificare potenziali farmaci, riducendo i tempi di sviluppo da decenni a anni. Aziende come DeepMind con AlphaFold hanno rivoluzionato la previsione della struttura proteica, aprendo nuove possibilità per la medicina personalizzata.</p>
-
 <h3>Ricerca sui Materiali</h3>
-
 <p>Algoritmi di machine learning possono prevedere le proprietà di nuovi materiali prima ancora che vengano sintetizzati, accelerando lo sviluppo di batterie più efficienti, superconduttori e materiali per l'energia rinnovabile.</p>
-
 <h3>Astronomia e Fisica</h3>
-
 <p>L'AI analizza enormi quantità di dati telescopici per identificare esopianeti, onde gravitazionali e altri fenomeni cosmici. Al CERN, algoritmi di AI processano i dati delle collisioni di particelle per identificare nuove particelle subatomiche.</p>
-
 <h2>L'AI nell'Educazione: Personalizzazione dell'Apprendimento</h2>
-
 <p>L'educazione sta vivendo una trasformazione guidata dall'AI:</p>
-
 <h3>Tutoring Personalizzato</h3>
-
 <p>Sistemi AI possono adattare il curriculum alle capacità e velocità di apprendimento individuali, identificando lacune nella conoscenza e fornendo esercizi mirati.</p>
-
 <h3>Valutazione Automatica</h3>
-
 <p>L'AI può valutare non solo risposte a scelta multipla, ma anche saggi, progetti creativi e presentazioni orali, fornendo feedback dettagliato e costruttivo.</p>
-
 <h3>Accessibilità</h3>
-
 <p>Strumenti AI rendono l'educazione più accessibile a studenti con disabilità attraverso trascrizione automatica, traduzione simultanea, e interfacce adattive.</p>
-
 <h2>Sfide Tecniche Attuali</h2>
-
 <h3>Il Problema dell'Hallucination</h3>
-
 <p>I modelli AI possono generare informazioni convincenti ma completamente false. Questo "allucinare" rappresenta una sfida critica per applicazioni dove l'accuratezza è vitale.</p>
-
 <h3>Interpretabilità</h3>
-
 <p>Molti sistemi AI, specialmente le reti neurali profonde, sono "black box" - funzionano efficacemente ma non possiamo spiegare esattamente come arrivano alle loro conclusioni.</p>
-
 <h3>Robustezza</h3>
-
 <p>I sistemi AI possono essere fragili, fallendo completamente di fronte a input leggermente diversi da quelli su cui sono stati addestrati.</p>
-
 <h3>Scaling Laws</h3>
-
 <p>Man mano che i modelli diventano più grandi, richiedono risorse computazionali esponenzialmente maggiori, sollevando questioni di sostenibilità e accessibilità.</p>
-
 <h2>Considerazioni Economiche</h2>
-
 <p>L'impatto economico dell'AI è già significativo e continua a crescere:</p>
-
 <h3>Investimenti e Mercato</h3>
-
 <p>Il mercato globale dell'AI è proiettato a raggiungere i 1.8 trilioni di dollari entro il 2030, con investimenti massicci da parte di governi e aziende private.</p>
-
 <h3>Nuovi Modelli di Business</h3>
-
 <p>L'AI sta creando nuovi modelli economici:</p>
-
 <ul>
 <li><strong>AI-as-a-Service</strong>: Accesso a capacità AI tramite API cloud</li>
 <li><strong>Freemium AI</strong>: Servizi AI gratuiti con funzionalità premium a pagamento  </li>
 <li><strong>AI marketplace</strong>: Piattaforme per vendere e comprare modelli AI specializzati</li>
 </ul>
-
 <h3>Concentrazione del Potere</h3>
-
 <p>La concentrazione delle risorse AI in poche grandi aziende tecnologiche solleva preoccupazioni antitrust e democratiche.</p>
-
 <h2>L'AI e la Creatività Umana</h2>
-
 <p>Contrariamente ai timori iniziali, l'AI non sta sostituendo la creatività umana ma la sta amplificando:</p>
-
 <h3>Collaborazione Creativa</h3>
-
 <p>Artisti, musicisti e scrittori utilizzano l'AI come strumento collaborativo, esplorando nuove forme espressive impossibili senza assistenza artificiale.</p>
-
 <h3>Democratizzazione degli Strumenti Creativi</h3>
-
 <p>L'AI rende accessibili strumenti creativi professionali a chiunque abbia un'idea, abbattendo barriere tecniche ed economiche.</p>
-
 <h3>Nuove Forme d'Arte</h3>
-
 <p>Emergono nuove categorie artistiche native dell'era AI, dalla arte generativa interattiva alle performance musicali umano-AI.</p>
-
 <h2>Implicazioni Geopolitiche</h2>
-
 <p>L'AI sta ridefinendo gli equilibri di potere globali:</p>
-
 <h3>Competizione Tecnologica</h3>
-
 <p>La "corsa all'AI" tra Stati Uniti, Cina, Europa e altre potenze sta influenzando politiche commerciali, investimenti in ricerca e alleanze internazionali.</p>
-
 <h3>Sovranità Digitale</h3>
-
 <p>I paesi stanno sviluppando strategie per mantenere il controllo sui propri dati e capacità AI, bilanciando innovazione e sicurezza nazionale.</p>
-
 <h3>Diplomazia dell'AI</h3>
-
 <p>Emergono nuove forme di cooperazione internazionale per stabilire norme globali sull'uso responsabile dell'AI.</p>
-
 <h2>Prospettive Future: Oltre il 2025</h2>
-
 <p>Guardando oltre l'orizzonte immediato, diverse tendenze sembrano emergere:</p>
-
 <h3>Artificial General Intelligence (AGI)</h3>
-
 <p>Mentre l'AGI rimane un obiettivo a lungo termine, i progressi incrementali verso sistemi più generalisti continueranno.</p>
-
 <h3>Quantum AI</h3>
-
 <p>L'integrazione tra computing quantistico e AI potrebbe sbloccare capacità computazionali rivoluzionarie.</p>
-
 <h3>Neuromorphic Computing</h3>
-
 <p>Chip ispirati al cervello umano potrebbero rendere l'AI più efficiente energeticamente e adatta per applicazioni edge.</p>
-
 <h3>Bio-AI Integration</h3>
-
 <p>L'interfaccia tra sistemi biologici e artificiali potrebbe portare a nuove forme di intelligenza ibrida.</p>
-
 <h2>Raccomandazioni per Navigare l'Era dell'AI</h2>
-
 <h3>Per Individui</h3>
-
 <ul>
 <li><strong>Lifelong Learning</strong>: Sviluppare competenze complementari all'AI</li>
 <li><strong>Digital Literacy</strong>: Comprendere i fondamenti dell'AI per essere cittadini informati</li>
 <li><strong>Critical Thinking</strong>: Mantenere capacità di valutazione critica dell'informazione</li>
 </ul>
-
 <h3>Per Organizzazioni</h3>
-
 <ul>
 <li><strong>Strategia AI</strong>: Sviluppare piani strategici per l'adozione dell'AI</li>
 <li><strong>Governance</strong>: Implementare framework etici e di governance</li>
 <li><strong>Talent</strong>: Investire in formazione e acquisizione di talenti AI</li>
 </ul>
-
 <h3>Per Governi</h3>
-
 <ul>
 <li><strong>Regolamentazione Agile</strong>: Sviluppare normative che promuovano innovazione responsabile</li>
 <li><strong>Investimenti Pubblici</strong>: Supportare ricerca e sviluppo AI</li>
 <li><strong>Educazione</strong>: Adattare sistemi educativi alle esigenze dell'era AI</li>
 </ul>
-
 <h2>Conclusione: L'AI Come Amplificatore del Potenziale Umano</h2>
-
 <p>Mentre concludiamo questo viaggio attraverso le applicazioni dell'intelligenza artificiale nel 2025, emerge un quadro complesso ma affascinante. L'AI non è più una tecnologia futuristica confinata nei laboratori di ricerca, ma una realtà pervasiva che sta ridefinendo ogni aspetto della nostra esistenza, dal modo in cui lavoriamo e comunichiamo, a come curiamo la nostra salute e creiamo arte.</p>
-
 <h3>Un Ecosistema di Innovazione in Continua Evoluzione</h3>
-
 <p>Quello che abbiamo osservato è un ecosistema tecnologico in rapida evoluzione, dove le applicazioni dell'AI si intrecciano e si amplificano reciprocamente. La visione artificiale alimenta i sistemi di guida autonoma, che a loro volta generano dati per migliorare gli algoritmi di navigazione. I modelli di linguaggio naturale potenziano gli assistenti virtuali, che diventano più capaci di gestire conversazioni complesse e supportare decisioni critiche. I sistemi esperti in medicina collaborano con robot chirurgici per interventi di precisione millimetrica.</p>
-
 <p>Questa sinergia tra diverse applicazioni AI sta creando quello che potremmo definire un "effetto moltiplicatore dell'intelligenza", dove il valore complessivo supera la somma delle singole parti. Non stiamo assistendo solo all'automazione di compiti specifici, ma all'emergere di un'intelligenza distribuita che pervade la nostra infrastruttura tecnologica.</p>
-
 <h3>Le Lezioni Apprese dal Gaming al Mondo Reale</h3>
-
 <p>Il percorso dell'AI dal gaming alle applicazioni del mondo reale ci insegna lezioni preziose. I giochi hanno fornito ambienti controllati dove testare e raffinare algoritmi complessi, dalla ricerca strategica negli scacchi all'apprendimento per rinforzo in Go. Questi successi hanno poi trovato applicazione in contesti ben più complessi: gli algoritmi che permettono a un'AI di navigare in un videogioco 3D ora guidano robot in magazzini automatizzati; le strategie apprese in simulazioni virtuali ottimizzano ora reti di distribuzione globali.</p>
-
 <p>Questa trasposizione dal virtuale al reale continua ad accelerare. Le simulazioni digitali avanzate permettono di testare sistemi AI in scenari infiniti prima del deployment nel mondo fisico, riducendo rischi e accelerando l'innovazione.</p>
-
 <h3>L'Intelligenza Artificiale Come Estensione Cognitiva</h3>
-
 <p>Una delle intuizioni più profonde che emergono dall'analisi delle applicazioni AI è la trasformazione del rapporto tra umani e macchine. L'AI non sta sostituendo l'intelligenza umana, ma la sta amplificando e complementando. I radiologi utilizzano l'AI per identificare anomalie che potrebbero sfuggire all'occhio umano, ma mantengono il ruolo cruciale nell'interpretazione clinica e nella relazione con il paziente. Gli artisti collaborano con sistemi generativi per esplorare nuove forme espressive, ma rimangono i curatori creativi del processo.</p>
-
 <p>Questa partnership cognitiva tra umani e AI rappresenta forse l'evoluzione più significativa del nostro tempo. Stiamo assistendo all'emergere di un'intelligenza ibrida, dove le capacità computazionali delle macchine si combinano con l'intuizione, la creatività e la saggezza umana.</p>
-
 <h3>Sfide Etiche e Sociali: Responsabilità Condivisa</h3>
-
 <p>L'ampia diffusione dell'AI porta con sé responsabilità enormi. Le questioni di bias algoritmico, privacy, trasparenza e controllo democratico della tecnologia non sono problemi tecnici da risolvere in laboratorio, ma sfide sociali che richiedono la partecipazione attiva di tutta la società.</p>
-
 <p>Il 2025 ci ha mostrato che l'AI può essere tanto un strumento di empowerment quanto uno di oppressione, a seconda di come viene sviluppata, implementata e governata. La differenza sta nelle scelte che facciamo come società: privilegi la efficienza sulla privacy? Accettiamo sistemi opachi in cambio di convenienza? Come bilanciamo automazione e lavoro umano?</p>
-
 <p>Queste domande non hanno risposte semplici, ma richiedono un dialogo continuo tra tecnologi, policymaker, accademici, aziende e cittadini. La governance dell'AI non può essere delegata agli esperti tecnici, ma deve essere un processo democratico e partecipativo.</p>
-
 <h3>Preparare il Futuro: Competenze per l'Era dell'AI</h3>
-
 <p>Per individui e organizzazioni, il messaggio è chiaro: l'adattamento all'era dell'AI non è un evento puntuale, ma un processo continuo. Le competenze che oggi sono centrali potrebbero diventare automatizzate domani, mentre emergono nuovi ruoli che oggi non esistono.</p>
-
 <p>La chiave è sviluppare competenze complementari all'AI:</p>
-
 <ul>
 <li><strong>Pensiero critico</strong> per valutare output e decisioni di sistemi AI</li>
 <li><strong>Creatività e innovazione</strong> per ideare applicazioni e soluzioni originali</li>
@@ -685,29 +490,17 @@
 <li><strong>Comprensione etica</strong> per navigare dilemmi morali complessi</li>
 <li><strong>Apprendimento continuo</strong> per adattarsi a cambiamenti tecnologici rapidi</li>
 </ul>
-
 <h3>Verso un Futuro di Abbondanza Intelligente</h3>
-
 <p>Guardando avanti, l'AI promette di affrontare alcune delle sfide più pressanti dell'umanità. Dai cambiamenti climatici alla povertà, dalle malattie rare all'esplorazione spaziale, l'intelligenza artificiale offre strumenti potenti per amplificare i nostri sforzi collettivi.</p>
-
 <p>Le applicazioni emergenti nell'energia rinnovabile, nella medicina personalizzata, nell'educazione adattiva e nella ricerca scientifica suggeriscono un futuro di "abbondanza intelligente" - un mondo dove le risorse cognitive sono ampiamente disponibili e accessibili, dove l'innovazione è accelerata e dove problemi complessi possono essere affrontati con approcci sofisticati e sfumati.</p>
-
 <h3>Il Ruolo dell'Italia e dell'Europa</h3>
-
 <p>Nel contesto globale dell'AI, l'Europa e l'Italia hanno un ruolo unico da giocare. Mentre altre regioni competono sulla potenza computazionale grezza o sulla velocità di deployment, l'Europa può guidare nello sviluppo di un'AI più etica, trasparente e centrata sull'uomo. L'approccio europeo alla regolamentazione dell'AI, con l'AI Act, rappresenta un tentativo di bilanciare innovazione e protezione dei diritti fondamentali. Questo "terzo modo" tra il capitalismo tecnologico americano e il controllo statale cinese potrebbe diventare un modello per il resto del mondo.</p>
-
 <h3>Riflessioni Finali: L'AI Come Specchio dell'Umanità</h3>
-
 <p>In ultima analisi, l'intelligenza artificiale è un riflesso della nostra umanità. I sistemi AI che creiamo incorporano i nostri valori, i nostri pregiudizi, le nostre aspirazioni e le nostre paure. Ogni algoritmo racconta una storia su chi siamo e su chi vogliamo diventare.</p>
-
 <p>Le applicazioni dell'AI che abbiamo esplorato - dal gaming alla medicina, dalla creatività alla governance - non sono semplicemente strumenti tecnologici, ma estensioni della nostra volontà collettiva di comprendere, creare, guarire e migliorare. Sono tentativi di codificare la saggezza umana in sistemi che possano amplificare le nostre capacità migliori.</p>
-
 <p>Il successo dell'AI non si misurerà solo in termini di prestazioni tecniche o profitti economici, ma nella sua capacità di contribuire a una società più giusta, creativa e prospera. Questo richiede che rimaniamo sempre vigili, critici e impegnati nel guidare lo sviluppo di questa tecnologia trasformativa.</p>
-
 <p>Man mano che ci addentriamo sempre più nell'era dell'AI, il nostro compito non è solo quello di sviluppare sistemi più intelligenti, ma di diventare noi stessi più saggi nell'utilizzarli. L'intelligenza artificiale può amplificare il nostro potenziale, ma spetta a noi decidere verso quale futuro dirigere questa amplificazione.</p>
-
 <p>Il viaggio nell'intelligenza artificiale è appena iniziato. Le applicazioni che abbiamo esaminato oggi sono solo il primo capitolo di una storia che si sta ancora scrivendo, una storia di cui tutti noi siamo co-autori. Il futuro dell'AI non è predeterminato: è il risultato delle scelte che facciamo oggi, individualmente e collettivamente.</p>
-
 <p>L'intelligenza artificiale non è il futuro - è il presente. E tocca a noi plasmarlo.</p>
 
             <div class="footer-back-button">

--- a/dist/04-AI_Creazione_Contenuti.html
+++ b/dist/04-AI_Creazione_Contenuti.html
@@ -162,114 +162,65 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>AI e Creazione di Contenuti: Il Presente e il Futuro della Creatività Digitale</h1>
-
 <p><em>di Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="Leonardo_Phoenix_10_a_cinematic_photograph_of_a_whimsical_arti_1.jpg" alt="Leonardo_Phoenix_10_a_cinematic_photograph_of_a_whimsical_arti_1.jpg" /></p>
-
+<img alt="Leonardo_Phoenix_10_a_cinematic_photograph_of_a_whimsical_arti_1.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/04-AI_Creazione_Contenuti/Leonardo_Phoenix_10_a_cinematic_photograph_of_a_whimsical_arti_1.jpg"/></p>
 <p><em>Dopo aver esplorato le applicazioni dell'intelligenza artificiale nei settori più disparati, dalla sanità alla finanza, dall'automotive all'agricoltura, è naturale volgere lo sguardo verso uno dei campi in cui l'AI sta dimostrando il potenziale più rivoluzionario: la creazione di contenuti. Qui, l'intelligenza artificiale non si limita ad automatizzare processi esistenti, ma sta letteralmente ridefinendo cosa significhi essere creativi, offrendo strumenti che permettono a chiunque di produrre contenuti di qualità professionale. Dalle immagini fotorealistiche generate da una semplice descrizione testuale, ai video creati partendo da un'idea, fino alla musica composta da algoritmi: siamo di fronte a una democratizzazione della creatività senza precedenti.</em></p>
-
 <h2>La Rivoluzione Creativa è Già Qui</h2>
-
 <p>Nel 2024, l'intelligenza artificiale ha consolidato la sua presenza nel panorama della creazione di contenuti, trasformando radicalmente il modo in cui produciamo e consumiamo media digitali. I dati parlano chiaro: il mercato globale della creazione di contenuti basata su AI dovrebbe raggiungere i 7,74 miliardi di dollari entro il 2029, con un tasso di crescita annuo del 21,6%, mentre oltre il 75% dei marketer ammette di utilizzare strumenti AI in qualche forma.</p>
-
 <p>Questa non è più una tecnologia emergente o sperimentale: è diventata parte integrante dei flussi di lavoro creativi moderni. Secondo PricewaterhouseCoopers, il 73% delle aziende statunitensi utilizza l'AI in qualche forma nel proprio business, e la creazione di contenuti rappresenta uno dei settori di applicazione più promettenti.</p>
-
 <h2>I Protagonisti della Creatività Artificiale</h2>
-
 <h3>Generazione di Immagini: Dall'Immaginazione alla Realtà</h3>
-
 <p><strong>DALL-E 3</strong>: Il sistema di OpenAI ha raggiunto livelli di sofisticazione straordinari. DALL-E 3 genera immagini che combinano elementi impossibili nella realtà con una coerenza visiva perfetta. La tecnologia ora gestisce dettagli complessi come riflessi, ombre e prospettive multiple con precisione fotografica.</p>
-
 <p><strong>Midjourney V6</strong>: Specializzato nella creazione artistica, eccelle nella generazione di opere che spaziano dal fotorealismo all'arte concettuale. Un caso d'uso significativo è quello degli studi di architettura che utilizzano Midjourney per visualizzare progetti, producendo rendering di qualità tale da essere indistinguibili da fotografie di edifici reali.</p>
-
 <p><strong>Leonardo AI</strong>: Si distingue per la capacità di mantenere coerenza stilistica attraverso serie di immagini. I brand di moda lo utilizzano per creare campagne pubblicitarie complete testando variazioni dello stesso concetto, mantenendo coerenza di stile e lighting.</p>
-
 <h3>Video Generation: Il Cinema AI-Powered</h3>
-
 <p><strong>Runway ML Gen-2</strong>: Ha democratizzato la produzione video professionale. Un esempio pratico: un'agenzia pubblicitaria ha creato uno spot di 30 secondi per un brand di orologi usando solo il prompt "Orologio di lusso che galleggia nell'acqua, slow motion, illuminazione cinematografica, riflessi dorati". Il risultato: un video di qualità broadcast prodotto in ore anziché settimane.</p>
-
 <p><strong>Synthesia</strong>: Rivoluziona la formazione aziendale. Una multinazionale ha creato corsi di training in 40 lingue diverse usando avatar AI: ogni dipendente può seguire la formazione nella propria lingua madre, con un presentatore virtuale che mantiene la stessa professionalità e coinvolgimento di un trainer umano.</p>
-
 <p><strong>Luma AI</strong>: Eccelle nella creazione di video tridimensionali. Un museo ha utilizzato questa tecnologia per creare tour virtuali immersivi: partendo da semplici fotografie degli ambienti, Luma AI genera percorsi video fluidi che permettono ai visitatori virtuali di "camminare" attraverso le sale espositive.</p>
-
 <h3>Generazione Musicale: L'Armonia Degli Algoritmi</h3>
-
 <p><strong>Suno AI</strong>: Ha raggiunto capacità compositive impressionanti. Un podcaster ha creato la sigla del suo show semplicemente scrivendo "Tema musicale energico per podcast di tecnologia, stile electronic rock, 30 secondi". Il risultato è una composizione originale, completa di arrangiamento e mix professionale.</p>
-
 <p><strong>Udio</strong>: Si specializza in generi specifici con precisione maniacale. Un produttore di giochi indie ha commissionato musiche per il suo RPG fantasy usando prompt dettagliati come "Tema epico per battaglia finale, orchestra sinfonica, coro epico, influenze di John Williams, 4 minuti". La colonna sonora risultante rivaleggia con produzioni AAA.</p>
-
 <p><strong>AIVA (Artificial Intelligence Virtual Artist)</strong>: Utilizzato per colonne sonore cinematografiche. Un documentario sulla natura ha utilizzato AIVA per creare l'intera colonna sonora: ogni brano è stato generato in base alle scene specifiche, dall'intimità di "Dolce melodia per scena di cuccioli di orso" all'epicità di "Musica drammatica per tempesta in montagna".</p>
-
 <h3>Text Generation: Quando l'AI Scrive</h3>
-
 <p><strong>GPT-4</strong>: Ha trasformato il copywriting professionale. Un'agenzia di marketing utilizza GPT-4 per creare campagne complete: da email marketing ("Scrivi una email promozionale per lancio prodotto tech, tono professionale ma amichevole, focus sui benefici") a post social ("Crea 10 post Instagram per brand di cosmetici naturali, hashtag inclusi, stile lifestyle").</p>
-
 <p><strong>Claude 3 Opus</strong>: Eccelle nella scrittura lunga e strutturata. Editori utilizzano Claude per creare outline dettagliati di libri: "Crea la struttura di un romanzo thriller ambientato nella Silicon Valley, protagonista donna detective, tema privacy digitale". Il risultato include trama, sviluppo personaggi e struttura narrativa professionale.</p>
-
 <p><strong>Jasper</strong>: Specializzato nel marketing content, viene usato da e-commerce per creare descrizioni prodotto ottimizzate SEO. Un negozio online ha automatizzato la creazione di schede prodotto: ogni articolo riceve automaticamente descrizione, benefici, specifiche tecniche e call-to-action personalizzate.</p>
-
 <h2>Il Decalogo del Prompt Engineering Perfetto</h2>
-
 <p>La qualità dell'output dipende direttamente dalla qualità dell'input. Ecco le dieci regole d'oro per comunicare efficacemente con l'AI, basate sulle migliori pratiche del prompt engineering del 2025:</p>
-
 <h3>1. Specificità è Potenza</h3>
-
 <ul>
 <li><strong>Male</strong>: "Crea un'immagine di un cane"</li>
 <li><strong>Bene</strong>: "Golden retriever adulto seduto su prato verde, luce del tramonto, fotografia ritratto, sfocatura dello sfondo, espressione felice, collare rosso"</li>
 </ul>
-
 <p>La specificità elimina l'ambiguità e guida l'AI verso risultati precisi. Ogni dettaglio aggiunto aumenta il controllo sul risultato finale.</p>
-
 <h3>2. Contesto Prima di Tutto</h3>
-
 <ul>
 <li><strong>Male</strong>: "Scrivi un articolo sui social media"</li>
 <li><strong>Bene</strong>: "Scrivi un articolo di 800 parole sui rischi dei social media per adolescenti, destinato a genitori preoccupati, tono comprensivo ma informativo, include statistiche recenti e consigli pratici"</li>
 </ul>
-
 <p>Il contesto definisce il quadro di riferimento: pubblico, scopo, tono e lunghezza guidano l'AI verso contenuti appropriati.</p>
-
 <h3>3. Struttura il Pensiero</h3>
-
 <p>Una delle tecniche più efficaci è il "chain of thought prompting", dove si incoraggia l'AI ad articolare il proprio processo di pensiero passo dopo passo.</p>
-
 <p><strong>Esempio</strong>: "Analizza questo problema di marketing passo dopo passo: 1) Identifica il target, 2) Analizza la concorrenza, 3) Proponi la strategia, 4) Giustifica la scelta"</p>
-
 <h3>4. Esempi Valgono Mille Parole</h3>
-
 <p>Il few-shot prompting è uno dei modi migliori per insegnare al modello il formato, lo stile e la portata esatti desiderati.</p>
-
 <p><strong>Template</strong>: "Scrivi titoli accattivanti per blog tech. Esempi: 'Come l'AI Sta Rivoluzionando il Gaming' → '5 Modi in cui l'AI Cambierà i Videogiochi per Sempre'. Ora crea un titolo per un articolo sulla cybersecurity domestica."</p>
-
 <h3>5. Definisci Ruoli e Personalità</h3>
-
 <p><strong>Potente</strong>: "Sei un esperto copywriter con 15 anni di esperienza nel settore luxury. Scrivi una descrizione prodotto per un orologio Rolex, enfatizzando tradizione e innovazione, per clienti facoltosi che apprezzano l'artigianalità."</p>
-
 <p>Assegnare ruoli specifici attiva diverse "modalità" nell'AI, influenzando vocabulary, stile e approccio.</p>
-
 <h3>6. Vincoli Creativi</h3>
-
 <p><strong>Esempio</strong>: "Scrivi una storia di 100 parole esatte che contenga: un robot, una rosa, il numero 42, e finisca con una domanda. Stile: realismo magico."</p>
-
 <p>I vincoli spesso stimolano maggiore creatività forzando l'AI a trovare soluzioni innovative dentro parametri definiti.</p>
-
 <h3>7. Iterazione e Raffinamento</h3>
-
 <p><strong>Processo</strong>:</p>
-
 <ul>
 <li>Primo prompt: risultato base</li>
 <li>Secondo prompt: "Migliora il precedente risultato aggiungendo più dettagli emotivi"</li>
 <li>Terzo prompt: "Ora riduci a metà lunghezza mantenendo l'impatto"</li>
 </ul>
-
 <p>L'iterazione permette raffinamenti progressivi verso l'obiettivo ideale.</p>
-
 <h3>8. Formattazione Chiara</h3>
-
 <p><strong>Efficace</strong>:</p>
-
 <pre><code>TASK: Crea piano marketing
 CONTEXT: Startup fintech, lancio app, budget 50k€
 FORMAT:
@@ -279,82 +230,46 @@ FORMAT:
 - KPI (metriche specifiche)
 TONE: Professionale, orientato ai risultati
 </code></pre>
-
 <h3>9. Gestione degli Edge Cases</h3>
-
 <p><strong>Robusto</strong>: "Genera email di benvenuto per nuovi utenti. Se l'utente non ha fornito il nome, usa 'Gentile Cliente'. Se la registrazione è premium, menziona vantaggi esclusivi. Se è weekend, aggiungi augurio per il fine settimana."</p>
-
 <p>Anticipare scenari diversi rende l'output più affidabile in situazioni reali.</p>
-
 <h3>10. Validazione e Fonti</h3>
-
 <p>Dirigere il modello a citare le proprie fonti aumenta l'affidabilità.</p>
-
 <p><strong>Esempio</strong>: "Spiega i benefici della meditazione includendo studi scientifici specifici. Per ogni affermazione, indica la fonte e l'anno della ricerca."</p>
-
 <h2>Il Presente: Uno Scenario in Rapida Evoluzione</h2>
-
 <p>Nel 2025, l'AI è diventata facilmente disponibile in quasi ogni aspetto della creazione di campagne pubblicitarie: targeting, variazioni di copy raccomandate, ottimizzazioni e molto altro. Questa pervasività sta ridefinendo non solo cosa creiamo, ma come lo creiamo.</p>
-
 <h3>Casi d'Uso Reali che Stanno Cambiando le Regole</h3>
-
 <p><strong>Netflix e la Personalizzazione Estrema</strong>: Ogni artwork che vedi su Netflix è potenzialmente generato da AI. Il sistema analizza i tuoi gusti, la tua cronologia di visualizzazione, perfino l'orario in cui navighi, per creare thumbnail personalizzati che massimizzano la probabilità di click.</p>
-
 <p><strong>Adobe e l'Integrazione Seamless</strong>: Photoshop 2025 include Firefly integrato direttamente nel workflow. Un designer può selezionare un'area dell'immagine e scrivere "aggiungi montagne innevate sullo sfondo" - l'AI completa l'operazione mantenendo prospettiva, illuminazione e stile coerenti.</p>
-
 <p><strong>Shopify e l'E-commerce Automatico</strong>: Migliaia di negozi online utilizzano AI per generare automaticamente descrizioni prodotto ottimizzate SEO in multiple lingue. Un venditore carica un'immagine del prodotto, l'AI genera titolo, descrizione, tag e persino suggerisce prezzi basati sull'analisi competitiva.</p>
-
 <h3>L'Impatto Economico Tangibile</h3>
-
 <p>Rispetto all'inizio del 2024, una percentuale maggiore di aziende riferisce che i casi d'uso dell'AI generativa hanno aumentato i ricavi all'interno delle unità di business che li implementano. Non si tratta più di un esperimento costoso, ma di un investimento che produce ROI misurabili.</p>
-
 <p>Una piccola agenzia di marketing ha ridotto i tempi di produzione del 70% utilizzando AI per:</p>
-
 <ul>
 <li>Brainstorming iniziale (GPT-4 per generare 50 idee creative in 5 minuti)</li>
 <li>Creazione asset visivi (Midjourney per mockup e concept)</li>
 <li>Copywriting multilingue (DeepL + GPT per localizzazione automatica)</li>
 <li>Video teaser (Runway ML per trailer di 30 secondi)</li>
 </ul>
-
 <p>Il risultato: da 3 settimane a 1 settimana per una campagna completa, con qualità mantenuta e costi ridotti del 60%.</p>
-
 <h2>Sfide e Considerazioni Etiche</h2>
-
 <h3>Il Paradosso dell'Autenticità</h3>
-
 <p>Mentre l'AI democratizza la creatività, solleva questioni profonde sull'autenticità. Quando un artista usa Midjourney per creare un'opera, chi è l'autore? La risposta non è semplice e varia per giurisdizione, ma la tendenza è verso un riconoscimento della "co-creazione" umano-AI.</p>
-
 <h3>Il Problema della Formazione</h3>
-
 <p>I modelli AI sono addestrati su enormi dataset che includono opere protette da copyright. Adobe ha risposto creando Firefly, addestrato esclusivamente su immagini di Adobe Stock e contenuti in pubblico dominio, offrendo protezione legale agli utenti commerciali.</p>
-
 <h3>L'Omogeneizzazione Creativa</h3>
-
 <p>Esiste il rischio che l'uso massivo degli stessi modelli AI porti a una standardizzazione estetica. La soluzione emerge dall'uso di modelli specializzati e dall'importante ruolo del prompt engineering nel differenziare gli output.</p>
-
 <h2>Il Futuro: Verso Nuovi Paradigmi Creativi</h2>
-
 <h3>Tendenze Emergenti per il 2025-2030</h3>
-
 <p><strong>AI Multimodale Avanzata</strong>: I prossimi modelli combineranno testo, immagini, audio e video in un unico flusso creativo. Immaginate di descrivere un'idea e ricevere automaticamente storyboard, colonna sonora, sceneggiatura e persino un trailer completo.</p>
-
 <p><strong>Personalizzazione Estrema</strong>: L'AI imparerà il vostro stile personale. Dopo aver analizzato i vostri lavori precedenti, potrà creare contenuti "alla vostra maniera", mantenendo la vostra voce creativa unica.</p>
-
 <p><strong>Collaboration Real-time</strong>: Team distribuiti globalmente lavoreranno su progetti creativi con AI che fungono da ponte linguistico e culturale, traducendo non solo parole ma concetti e riferimenti culturali.</p>
-
 <p><strong>Quality Control Automatico</strong>: L'AI non solo creerà contenuti, ma li valuterà automaticamente per coerenza di brand, appropriatezza culturale, potenziale virale e conformità legale.</p>
-
 <h3>Tecnologie all'Orizzonte</h3>
-
 <p><strong>Neural Architecture Search (NAS)</strong>: L'AI progetta se stessa, creando architetture ottimizzate per compiti creativi specifici. Questo porterà a modelli specializzati incredibilmente efficienti.</p>
-
 <p><strong>Quantum-Enhanced AI</strong>: I computer quantistici accelereranno drammaticamente l'addestramento di modelli creativi, permettendo AI che comprendono sfumature creative oggi impensabili.</p>
-
 <p><strong>Brain-Computer Interface Creative</strong>: Nei prossimi 10 anni, potrebbero emergere interfacce che traducono direttamente l'intenzione creativa in output digitale, bypassando completamente il processo di prompt writing.</p>
-
 <h3>Previsioni Concrete per il 2030</h3>
-
 <ol>
 <li><p><strong>100% Automation Ready</strong>: Interi workflow creativi saranno automatizzabili, dalla brief iniziale alla delivery finale, con intervento umano solo per approvazione e direzione strategica.</p></li>
 <li><p><strong>Real-time Content</strong>: I contenuti si adatteranno in tempo reale al pubblico. Un annuncio pubblicitario cambierà colori, musica e messaggio basandosi su chi lo sta guardando.</p></li>
@@ -362,43 +277,30 @@ TONE: Professionale, orientato ai risultati
 <li><p><strong>Cross-Reality Creation</strong>: L'AI creerà contenuti nativamente per realtà aumentata, virtuale e mista, con esperienze immersive impossibili da distinguere dalla realtà.</p></li>
 <li><p><strong>Emotional AI</strong>: I sistemi riconosceranno e risponderanno alle emozioni in tempo reale, adattando contenuti per massimizzare impatto emotivo positivo.</p></li>
 </ol>
-
 <h2>Prepararsi al Futuro: Cosa Fare Oggi</h2>
-
 <h3>Per i Creativi</h3>
-
 <ul>
 <li><strong>Imparate il Prompt Engineering</strong>: Diventerà importante quanto saper usare Photoshop</li>
 <li><strong>Specializzatevi nella Direzione Creativa</strong>: L'AI eseguirà, voi dovrete guidare</li>
 <li><strong>Mantenete la Vostra Voce</strong>: L'originalità sarà più preziosa che mai</li>
 </ul>
-
 <h3>Per le Aziende</h3>
-
 <ul>
 <li><strong>Investite in Formazione</strong>: I vostri team devono acquisire competenze AI oggi</li>
 <li><strong>Ripensate i Workflow</strong>: Molti processi creativi andranno completamente ridisegnati</li>
 <li><strong>Considerate l'Etica</strong>: Sviluppate politiche chiare sull'uso dell'AI creativa</li>
 </ul>
-
 <h3>Per gli Educatori</h3>
-
 <ul>
 <li><strong>Integrate l'AI nei Curricula</strong>: Gli studenti devono imparare a collaborare con l'AI</li>
 <li><strong>Enfatizzate il Pensiero Critico</strong>: Diventerà cruciale per dirigere efficacemente l'AI</li>
 <li><strong>Preparate alle Nuove Professioni</strong>: Emergeranno ruoli completamente nuovi</li>
 </ul>
-
 <h2>Conclusione: La Creatività Aumentata</h2>
-
 <p>Siamo all'alba di una nuova era creativa. L'intelligenza artificiale non sostituisce la creatività umana, ma la amplifica, la democratizza e la accelera. Come ogni rivoluzione tecnologica, porta opportunità straordinarie insieme a sfide significative.</p>
-
 <p>Entro il 2025, l'AI potrebbe eliminare 85 milioni di posti di lavoro ma crearne 97 milioni di nuovi, risultando in un guadagno netto di 12 milioni di posti. Nel settore creativo, questo si traduce in una trasformazione piuttosto che una sostituzione: emergono nuovi ruoli come AI Art Director, Prompt Engineer, AI Content Strategist.</p>
-
 <p>Il segreto per navigare questa transizione è abbracciare l'AI come un partner creativo potente, imparando a comunicare efficacemente con questi sistemi attraverso tecniche di prompt engineering sempre più sofisticate. Chi padroneggerà quest'arte avrà un vantaggio competitivo enorme nel panorama creativo del futuro.</p>
-
 <p>La domanda non è se l'AI cambierà la creatività - l'ha già fatto. La domanda è se saremo pronti a guidare questo cambiamento o se lasceremo che ci travolga. La scelta, almeno per ora, è ancora nostra.</p>
-
 <p><em>La prossima volta che vedrete un'immagine straordinaria, un video coinvolgente o leggerete un testo che vi colpisce, ricordatevi: potrebbe essere il frutto di una collaborazione tra intelligenza umana e artificiale. E questa è solo l'inizio della storia.</em></p>
 
             <div class="footer-back-button">

--- a/dist/05-AI Aziende e Servizi.html
+++ b/dist/05-AI Aziende e Servizi.html
@@ -162,398 +162,202 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>Il Panorama dell'Intelligenza Artificiale: Giganti Tecnologici, Sfide Competitive e gli Strumenti che Democratizzano l'IA</h1>
-
 <p><em>di Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="Leonardo_Phoenix_10_A_fiercely_competitive_scene_in_the_world_1.jpg" alt="Leonardo_Phoenix_10_A_fiercely_competitive_scene_in_the_world_1.jpg" /></p>
-
+<img alt="Leonardo_Phoenix_10_A_fiercely_competitive_scene_in_the_world_1.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/05-AI Aziende e Servizi/Leonardo_Phoenix_10_A_fiercely_competitive_scene_in_the_world_1.jpg"/></p>
 <p><em>Dopo aver esplorato nei precedenti articoli le basi teoriche dell'intelligenza artificiale, le tecniche che la alimentano, le sue applicazioni nel mondo del lavoro e dello studio, e le incredibili possibilità dell'IA generativa, è tempo di voltare lo sguardo verso il cuore pulsante di questa rivoluzione: le aziende che stanno plasmando il futuro dell'IA e gli strumenti che la rendono accessibile a tutti noi.</em></p>
-
 <p>Il 2025 si è aperto con uno scenario competitivo senza precedenti nel mondo dell'intelligenza artificiale. Nel solo gennaio 2025, i finanziamenti globali hanno raggiunto i 26 miliardi di dollari, con le aziende AI che hanno ottenuto 5,7 miliardi, rappresentando il 22% dell'intero mercato dei finanziamenti. Questi numeri testimoniano non solo l'interesse crescente degli investitori, ma anche la maturazione di un settore che sta ridefinendo l'economia globale.</p>
-
 <p>Ma cosa si nasconde dietro questi investimenti miliardari? Chi sono i protagonisti di questa trasformazione e quali strumenti stanno mettendo a disposizione per democratizzare l'accesso all'IA? Scopriamolo insieme in questo viaggio attraverso il panorama aziendale e tecnologico dell'intelligenza artificiale.</p>
-
 <h2>La Corsa dei Giganti: Le Aziende che Guidano la Rivoluzione IA</h2>
-
 <h3>Meta: Il Metaverso Incontra l'Intelligenza Artificiale</h3>
-
 <p>Meta, l'azienda madre di Facebook, Instagram e WhatsApp, ha fatto dell'intelligenza artificiale uno dei pilastri della sua strategia di trasformazione. Con un investimento superiore ai 30 miliardi di dollari in infrastrutture GPU, Meta sta costruendo le fondamenta per un futuro dove il metaverso e l'IA si fondono in un'unica esperienza immersiva.</p>
-
 <p>Il progetto Llama, giunto alla sua terza iterazione, rappresenta l'approccio "open-source" di Meta all'IA. Llama 3, con le sue diverse varianti da 8 miliardi a 405 miliardi di parametri, ha dimostrato che è possibile competere con i modelli proprietari mantenendo un approccio aperto alla ricerca. Questa filosofia non è solo filantropica: permettendo alla comunità scientifica di accedere e migliorare i modelli, Meta accelera l'innovazione e riduce i costi di sviluppo.</p>
-
-<p>L'integrazione dell'IA nei prodotti Meta è già tangibile: dall'algoritmo che determina cosa vediamo nel nostro feed di Facebook agli strumenti di creazione automatica di contenuti per le aziende su Instagram. Ma l'ambizione va oltre: Meta sta sviluppando assistenti virtuali che accompagneranno gli utenti nel metaverso, capaci di comprendere il linguaggio naturale, le emozioni e persino il linguaggio del corpo.<br><br><br></p>
-
+<p>L'integrazione dell'IA nei prodotti Meta è già tangibile: dall'algoritmo che determina cosa vediamo nel nostro feed di Facebook agli strumenti di creazione automatica di contenuti per le aziende su Instagram. Ma l'ambizione va oltre: Meta sta sviluppando assistenti virtuali che accompagneranno gli utenti nel metaverso, capaci di comprendere il linguaggio naturale, le emozioni e persino il linguaggio del corpo.<br/><br/><br/></p>
 <h3>OpenAI: Pionieri dell'IA Conversazionale</h3>
-
 <p>OpenAI rimane l'azienda che ha portato l'IA all'attenzione del grande pubblico con il lancio di ChatGPT nel novembre 2022. Sotto la guida di Sam Altman, l'azienda ha mantenuto la sua posizione di leadership nell'IA conversazionale, continuando a spingere i confini di ciò che è possibile con il linguaggio naturale.</p>
-
 <p>GPT-4, il modello di punta di OpenAI, ha stabilito nuovi standard per la comprensione e generazione del linguaggio, dimostrando capacità che vanno dalla scrittura creativa alla risoluzione di problemi matematici complessi. Ma OpenAI non si ferma qui: l'azienda sta lavorando su GPT-5 e sui successivi modelli che promettono di avvicinarsi sempre di più all'intelligenza artificiale generale (AGI).</p>
-
 <p>DALL-E, il sistema di generazione di immagini da testo, ha rivoluzionato il mondo della creatività digitale, permettendo a chiunque di diventare un artista digitale semplicemente descrivendo ciò che immagina. La terza versione, DALL-E 3, integrata in ChatGPT, ha reso questa tecnologia accessibile a milioni di utenti in tutto il mondo.</p>
-
 <p>Il modello di business di OpenAI, che combina servizi gratuiti e premium, ha dimostrato che l'IA può essere sia accessibile che profittevole. Con milioni di utenti attivi e partnership strategiche con aziende come Microsoft, OpenAI ha creato un ecosistema che alimenta l'innovazione in numerosissimi settori.</p>
-
 <h3>Microsoft: L'Integrazione dell'IA nell'Ecosistema Aziendale</h3>
-
 <p>Microsoft ha fatto una scommessa coraggiosa sull'intelligenza artificiale, investendo pesantemente in OpenAI e integrando l'IA in praticamente tutti i suoi prodotti. L'azienda ha annunciato investimenti per 75 miliardi di dollari in infrastrutture AI per il 2025, una cifra che testimonia l'impegno totale verso questa tecnologia.</p>
-
 <p>Copilot, l'assistente IA di Microsoft, è probabilmente l'esempio più tangibile di come l'intelligenza artificiale possa essere integrata senza soluzione di continuità nella vita lavorativa quotidiana. Disponibile in Word, Excel, PowerPoint, Outlook e Teams, Copilot non si limita a automatizzare compiti ripetitivi, ma diventa un vero partner creativo, aiutando a generare idee, analizzare dati e migliorare la produttività.</p>
-
 <p>Azure AI, la piattaforma cloud di Microsoft, offre agli sviluppatori e alle aziende gli strumenti per creare e distribuire applicazioni IA su scala globale. Con servizi che vanno dal riconoscimento vocale all'analisi predittiva, Azure AI sta democratizzando l'accesso alle tecnologie più avanzate, permettendo anche alle piccole e medie imprese di beneficiare della potenza dell'intelligenza artificiale.</p>
-
 <p>L'acquisizione di GitHub e lo sviluppo di GitHub Copilot hanno rivoluzionato anche il mondo della programmazione, dove l'IA non sostituisce i programmatori ma li potenzia, suggerendo codice, identificando bug e accelerando lo sviluppo software.</p>
-
 <h3>Google e DeepMind: L'IA al Servizio della Conoscenza</h3>
-
 <p>Google, con la sua filiale DeepMind, rappresenta forse l'approccio più scientifico all'intelligenza artificiale. L'azienda di Mountain View ha trasformato l'IA da progetto di ricerca a motore di crescita, integrando algoritmi intelligenti in ogni aspetto dei suoi servizi.</p>
-
 <p>Gemini Ultra, il modello di linguaggio di Google, compete direttamente con GPT-4 in termini di capacità e prestazioni, ma con un vantaggio importante: l'accesso in tempo reale alle informazioni web. Questa caratteristica rende Gemini particolarmente potente per compiti che richiedono informazioni aggiornate o verifiche fattuali.</p>
-
 <p>DeepMind ha continuato a stupire il mondo scientifico con risultati rivoluzionari. Dopo AlphaGo, che ha sconfitto i campioni mondiali di Go, l'azienda ha sviluppato AlphaFold, che ha risolto uno dei problemi più complessi della biologia: la predizione della struttura delle proteine. Questo risultato non è solo un trionfo tecnologico, ma promette di accelerare la ricerca medica e farmaceutica in modi che erano impensabili solo pochi anni fa.</p>
-
-<p>TensorFlow, la piattaforma open-source di Google per il machine learning, ha democratizzato lo sviluppo di applicazioni IA, fornendo a ricercatori e sviluppatori in tutto il mondo gli strumenti per creare i propri modelli intelligenti.<br><br><br><br><br></p>
-
+<p>TensorFlow, la piattaforma open-source di Google per il machine learning, ha democratizzato lo sviluppo di applicazioni IA, fornendo a ricercatori e sviluppatori in tutto il mondo gli strumenti per creare i propri modelli intelligenti.<br/><br/><br/><br/><br/></p>
 <h2>I Nuovi Sfidanti: L'innovazione dirompente nel Mercato IA</h2>
-
 <h3>Anthropic: Sicurezza e Affidabilità al Centro</h3>
-
 <p>Anthropic, supportata da Amazon con una valutazione di 61 miliardi di dollari, ha recentemente lanciato i suoi modelli più potenti: Claude 4 Opus e Claude 4 Sonnet. L'azienda, fondata da ex ricercatori di OpenAI, ha fatto della sicurezza e dell'affidabilità dell'IA la sua missione principale.</p>
-
 <p>Claude 4 rappresenta un significativo passo avanti nell'IA conversazionale, con capacità di ragionamento e risoluzione di problemi che, secondo i benchmark, sono tra le migliori del settore. Ma ciò che distingue Anthropic non sono solo le prestazioni tecniche, bensì l'approccio metodico alla sicurezza AI.</p>
-
 <p>La ricerca di Anthropic su "Constitutional AI", ovvero un metodo di addestramento dei modelli che guida il comportamento dell'IA fornendo un chiaro insieme di regole etiche, sta definendo nuovi standard per lo sviluppo di sistemi IA che possano essere allineati con i valori umani senza sacrificare le prestazioni. Questo approccio sta influenzando l'intero settore, spingendo anche i concorrenti a considerare più seriamente gli aspetti etici e di sicurezza.</p>
-
 <h3>Elon Musk e xAI: La Sfida della Trasparenza</h3>
-
 <p>Elon Musk, mai pago di rivoluzionare un solo settore alla volta, ha lanciato xAI con l'ambizioso obiettivo di creare "l'IA più veritiera del pianeta". Grok, il modello di linguaggio di xAI, si distingue per il suo approccio diretto e spesso sarcastico, in contrasto con il tono più conservativo dei suoi concorrenti.</p>
-
 <p>L'integrazione di Grok con la piattaforma X (ex Twitter) offre al modello accesso a informazioni in tempo reale e conversazioni globali, creando un'esperienza IA unica nel suo genere. Musk ha promesso che xAI sarà completamente trasparente sui suoi algoritmi e processi di training, una mossa che potrebbe ridefinire gli standard di accountability nel settore.</p>
-
 <p>L'approccio di xAI alla sicurezza IA è diverso da quello di Anthropic: invece di limitare le capacità del modello, Musk sostiene che la trasparenza totale sia la chiave per garantire che l'IA rimanga benefica per l'umanità.</p>
-
 <p>Tuttavia, le promesse di trasparenza totale meritano di essere valutate con prudenza alla luce dei precedenti di Musk in altre iniziative. Le tempistiche della guida autonoma Tesla, ripetutamente posticipate, e l'evoluzione delle politiche di moderazione su X dimostrano come le dichiarazioni iniziali possano subire modifiche sostanziali nel tempo.</p>
-
 <p>Inoltre, lo stesso Musk fu co-fondatore di OpenAI con una missione originariamente open-source, poi evolutasi verso un modello più commerciale e chiuso. La vera sfida per xAI sarà tradurre le promesse di apertura in pratiche verificabili e sostenibili nel lungo termine.</p>
-
 <h3>Tesla AI: L'IA su Quattro Ruote e Due Gambe</h3>
-
 <p>Tesla rappresenta forse l'applicazione più visibile e tangibile dell'intelligenza artificiale nella vita quotidiana. Il sistema Autopilot ha evoluto la guida autonoma da fantascienza a realtà commerciale, utilizzando una combinazione di reti neurali convoluzionali e algoritmi di apprendimento per rinforzo.</p>
-
 <p>La strategia "vision-only" di Tesla, che si basa esclusivamente su telecamere invece di costosi sensori LiDAR, ha dimostrato che l'IA può raggiungere prestazioni sorprendenti anche con hardware relativamente semplice. Questa scelta ha reso la guida autonoma più accessibile dal punto di vista economico, accelerando l'adozione di massa.</p>
-
 <p>Optimus, il robot umanoide di Tesla, rappresenta l'evoluzione naturale delle competenze IA dell'azienda. Utilizzando gli stessi algoritmi sviluppati per la guida autonoma, Optimus promette di portare l'intelligenza artificiale dal mondo digitale a quello fisico, con applicazioni che vanno dalla manifattura alla assistenza domestica.</p>
-
 <h3>DeepSeek: Il Rivoluzionario Cinese che Ha Scosso l'Industria</h3>
-
 <p>DeepSeek, una startup cinese IA, ha sconvolto il panorama dell'intelligenza artificiale con il suo modello open-source R1 che non solo rende accessibile la tecnologia IA avanzata, ma dimostra anche un approccio unico allo sviluppo dell'IA, enfatizzando prestazioni, cost-effectiveness e trasparenza.</p>
-
 <p>DeepSeek R1 è stato elogiato dai ricercatori per la sua capacità di affrontare compiti di ragionamento complessi, particolarmente in matematica e coding. Il modello utilizza un approccio "chain of thought" simile a quello utilizzato da ChatGPT o1, che gli permette di risolvere problemi processando le query passo dopo passo.</p>
-
 <p>Ciò che rende DeepSeek davvero rivoluzionario è la sua efficienza: i ricercatori di DeepSeek hanno trovato un modo per ottenere più potenza computazionale dai chip NVIDIA, permettendo ai modelli fondamentali di essere addestrati con significativamente meno potenza computazionale. Aziende più piccole e startup potranno ora replicare... risultati simili a costi molto inferiori.</p>
-
 <p>Questo breakthrough ha dimostrato che l'innovazione nell'IA non dipende necessariamente da budget miliardari o dai chip più avanzati, ma da ingegnosità e ottimizzazione intelligente. DeepSeek ha essenzialmente democratizzato l'accesso a capacità IA di livello enterprise.</p>
-
 <h3>Perplexity AI: Rivoluzionare la Ricerca con l'IA</h3>
-
 <p>Perplexity AI, con una valutazione che ha raggiunto i 14 miliardi di dollari, si sta posizionando come un formidabile sfidante di realtà storiche come Google e Apple con il suo approccio innovativo alla ricerca e i piani per lanciare un nuovo browser.</p>
-
 <p>La differenza chiave tra Perplexity e concorrenti come OpenAI e Anthropic? Informazioni in tempo reale con attribuzione. Mentre i modelli GPT eccellono nella conoscenza generale e Claude offre comprensione sfumata, Perplexity aggiunge quella dimensione cruciale di dati attuali e verificati.</p>
-
 <p>Perplexity AI si sta preparando a lanciare un fondo da 50 milioni di dollari focalizzato su startup di intelligenza artificiale in fase pre-seed e seed negli Stati Uniti, dimostrando la sua ambizione di diventare non solo un player tecnologico ma anche un catalizzatore per l'innovazione nell'ecosistema IA.</p>
-
 <p>L'azienda ha trasformato la ricerca da una lista di link a una conversazione intelligente, fornendo risposte precise con citazioni verificabili. Questo approccio sta ridefinendo come interagiamo con l'informazione online.</p>
-
 <h2>L'Infrastruttura che Alimenta l'IA: I Fornitori Tecnologici</h2>
-
 <h3>NVIDIA: Il Motore dell'IA Moderna</h3>
-
 <p>NVIDIA ha dominato il mercato dei semiconduttori per IA, con ricavi 2024 aumentati del 114% raggiungendo 130,5 miliardi di dollari. L'azienda non produce solo chip, ma sta creando l'intero ecosistema tecnologico che alimenta la rivoluzione IA.</p>
-
 <p>Le GPU NVIDIA, originariamente progettate per il gaming, si sono rivelate perfette per l'elaborazione parallela richiesta dall'IA. La serie H100 e la nuova architettura Blackwell stanno definendo i nuovi standard per l'addestramento di modelli IA su larga scala.</p>
-
 <p>CUDA, la piattaforma di programmazione parallela di NVIDIA, è diventata il linguaggio standard per lo sviluppo IA. Imparare CUDA è oggi essenziale per chiunque voglia lavorare seriamente nel campo dell'intelligenza artificiale.</p>
-
 <p>Ma NVIDIA non si ferma all'hardware: l'azienda sta sviluppando strumenti software come NVIDIA AI Enterprise e Omniverse, che rendono più semplice per le aziende sviluppare e distribuire applicazioni IA.</p>
-
 <h3>IBM: L'IA Enterprise Heritage</h3>
-
 <p>IBM, con la sua lunga storia nell'informatica aziendale, porta una prospettiva unica all'IA moderna. Watson, pur non avendo raggiunto le aspettative iniziali come sistema di question-answering generale, ha trovato applicazioni di successo in settori specifici come la sanità e la finanza.</p>
-
 <p>L'approccio IBM all'IA si concentra su affidabilità, sicurezza e compliance - caratteristiche essenziali per le grandi aziende che devono rispettare rigide normative. IBM Cloud offre strumenti IA enterprise-ready che garantiscono la conformità con standard come GDPR e HIPAA.</p>
-
 <p>La recente acquisizione di Red Hat ha rafforzato la posizione di IBM nell'IA cloud, combinando l'expertise in intelligenza artificiale con le competenze in container e orchestrazione.</p>
-
 <h3>Amazon: L'IA nell'E-commerce e Oltre</h3>
-
 <p>Amazon è stata probabilmente la prima azienda a portare l'IA nelle case di milioni di persone attraverso Alexa. L'assistente vocale ha dimostrato che l'interazione naturale con l'IA poteva essere tanto utile quanto divertente.</p>
-
 <p>AWS, la divisione cloud di Amazon, offre una delle piattaforme IA più complete del mercato. Da SageMaker per il machine learning a Rekognition per l'analisi di immagini, AWS fornisce gli strumenti per ogni aspetto dello sviluppo IA.</p>
-
 <p>L'uso interno dell'IA in Amazon è forse ancora più impressionante: dai sistemi di raccomandazione che suggeriscono prodotti all'ottimizzazione logistica che gestisce milioni di spedizioni quotidiane, l'IA è il motore silenzioso che alimenta l'impero e-commerce di Amazon.</p>
-
 <h2>Strumenti e Piattaforme: Democratizzare l'Intelligenza Artificiale</h2>
-
 <h3>Piattaforme di Sviluppo: Gli Strumenti del Mestiere</h3>
-
 <p><strong>TensorFlow</strong> rimane la piattaforma di riferimento per molti sviluppatori IA. Creata da Google, questa libreria open-source ha reso accessibile lo sviluppo di reti neurali complesse, fornendo un ecosistema completo che va dalla prototipazione alla produzione su larga scala.</p>
-
 <p>La forza di TensorFlow risiede nella sua flessibilità: che tu stia sviluppando un modello per riconoscere immagini mediche o un sistema di traduzione automatica, TensorFlow fornisce gli strumenti necessari. TensorFlow Lite permette di portare questi modelli su dispositivi mobili, mentre TensorFlow.js li rende accessibili direttamente nei browser web.</p>
-
 <p><strong>PyTorch</strong>, sviluppato da Facebook (ora Meta), ha guadagnato popolarità soprattutto tra i ricercatori per la sua approach più intuitiva al debugging e alla sperimentazione. Il suo grafo computazionale dinamico permette di modificare i modelli in tempo reale, rendendo più semplice l'innovazione e la sperimentazione.</p>
-
 <p>La battaglia tra TensorFlow e PyTorch ha portato benefici a tutta la comunità IA: entrambe le piattaforme hanno dovuto migliorare costantemente per rimanere competitive, risultando in strumenti sempre più potenti e accessibili.</p>
-
-<p><strong>Keras</strong>, ora integrata in TensorFlow, ha mantenuto la sua filosofia di semplicità. Per molti sviluppatori alle prime armi, Keras rappresenta il primo approccio al deep learning, fornendo un'interfaccia high-level che nasconde la complessità sottostante senza limitare le possibilità.<br><br><br><br><br></p>
-
+<p><strong>Keras</strong>, ora integrata in TensorFlow, ha mantenuto la sua filosofia di semplicità. Per molti sviluppatori alle prime armi, Keras rappresenta il primo approccio al deep learning, fornendo un'interfaccia high-level che nasconde la complessità sottostante senza limitare le possibilità.<br/><br/><br/><br/><br/></p>
 <h3>Servizi Cloud: L'IA as a Service</h3>
-
 <p>L'emergere dei servizi cloud IA ha drasticamente ridotto le barriere di ingresso per lo sviluppo di applicazioni intelligenti. Non è più necessario essere un esperto di machine learning per integrare funzionalità IA nelle proprie applicazioni.</p>
-
 <p><strong>Google Cloud AI</strong> offre servizi pronti all'uso per compiti comuni come il riconoscimento di immagini, l'analisi del sentiment e la traduzione automatica. AutoML va oltre, permettendo di addestrare modelli personalizzati senza scrivere codice, democratizzando ulteriormente l'accesso all'IA.</p>
-
 <p><strong>Microsoft Azure AI</strong> si distingue per l'integrazione con l'ecosistema Microsoft. Cognitive Services fornisce API per funzionalità IA comuni, mentre Azure Machine Learning offre un ambiente completo per lo sviluppo di modelli personalizzati.</p>
-
 <p><strong>Amazon Web Services (AWS) AI</strong> combina la potenza dell'infrastruttura AWS con strumenti IA avanzati. SageMaker ha rivoluzionato il modo in cui i data scientist lavorano, fornendo un ambiente integrato che copre l'intero ciclo di vita del machine learning.</p>
-
 <p>Questi servizi cloud stanno trasformando l'IA da tecnologia di nicchia a utility globale, accessibile a qualsiasi sviluppatore o azienda con una connessione internet.</p>
-
 <h3>Strumenti Specializzati: IA per Ogni Dominio</h3>
-
 <p><strong>Hugging Face</strong> ha rivoluzionato il mondo del Natural Language Processing (NLP) creando un hub centralizzato per modelli pre-addestrati. La loro libreria Transformers ha reso accessibili modelli state-of-the-art come BERT, GPT, e T5, permettendo a sviluppatori di tutto il mondo di costruire applicazioni NLP sofisticate in poche righe di codice.</p>
-
 <p>Il modello di business di Hugging Face - combinare open source con servizi premium - sta diventando un template per molte startup IA. La loro piattaforma ospita decine di migliaia di modelli, creando un vero marketplace dell'intelligenza artificiale.</p>
-
 <p><strong>OpenCV</strong> continua a essere il riferimento per la computer vision. Questa libreria, sviluppata inizialmente da Intel, fornisce gli strumenti fondamentali per l'analisi di immagini e video. Dall'identificazione di oggetti al tracking in tempo reale, OpenCV è alla base di innumerevoli applicazioni di visione artificiale.</p>
-
 <p><strong>spaCy</strong> ha semplificato l'elaborazione del linguaggio naturale, fornendo un'interfaccia pulita e prestazioni ottimizzate per compiti comuni come l'estrazione di entità e l'analisi sintattica. La sua filosofia "industrial-strength" lo rende ideale per applicazioni production.</p>
-
 <h2>Il Panorama Competitivo Attuale: Sfide e Opportunità</h2>
-
 <h3>La Corsa agli Investimenti</h3>
-
 <p>Secondo ricerche EY, il 34% delle aziende che già investono in IA pianifica di investire 10 milioni di dollari o più nel prossimo anno, un aumento rispetto al 30% di sei mesi fa. Questo trend dimostra che l'IA non è più vista come un esperimento, ma come un investimento strategico essenziale.</p>
-
 <p>Nel 2024, gli investimenti in startup IA hanno contribuito significativamente alla ripresa dei finanziamenti venture capital negli Stati Uniti, con il capitale totale raccolto quasi 30% più alto anno su anno. Questi numeri indicano che, nonostante l'hype iniziale, gli investitori continuano a vedere valore reale nell'IA.</p>
-
 <p>Tuttavia, gli esperti prevedono che il ritmo frenetico degli investimenti del 2024 continuerà nel 2025, ma non senza volatilità continua. Questo suggerisce che mentre l'interesse per l'IA rimane alto, il mercato sta diventando più selettivo, premiando aziende con prodotti concreti e modelli di business sostenibili.</p>
-
 <h3>La Sfida della Differenziazione</h3>
-
 <p>Con centinaia di aziende che competono nello spazio IA, la differenziazione è diventata cruciale. Non basta più avere un modello di linguaggio competitivo; le aziende devono trovare nicchie specifiche o approcci unici per distinguersi.</p>
-
 <p>Anthropic ha scelto la sicurezza e l'affidabilità come differenziatori principali. OpenAI punta sull'accessibilità e l'integrazione. Google sfrutta il suo accesso ai dati web. Microsoft si concentra sull'integrazione enterprise. Ogni player principale sta definendo la propria proposta di valore unica.</p>
-
 <p>Questa specializzazione è benefica per il mercato: invece di una soluzione IA universale, stiamo vedendo l'emergere di strumenti specializzati che eccellono in domini specifici.</p>
-
 <h3>L'Evoluzione dei Modelli di Business</h3>
-
 <p>Il settore IA sta sperimentando diversi modelli di business, ognuno con i propri vantaggi e sfide:</p>
-
 <p><strong>Freemium</strong>: Offrire un servizio base gratuito con funzionalità premium a pagamento. Questo modello ha funzionato bene per OpenAI e Anthropic, permettendo di costruire una base utenti ampia mentre si generano ricavi dagli utenti più attivi.</p>
-
 <p><strong>API-first</strong>: Fornire IA come servizio attraverso API. Questo modello, adottato da molte startup, permette di scalare rapidamente senza dover costruire applicazioni front-end complesse.</p>
-
 <p><strong>Enterprise SaaS</strong>: Vendere soluzioni IA complete alle aziende. Questo modello offre ricavi ricorrenti più stabili ma richiede team di vendita e supporto più grandi.</p>
-
 <p><strong>Open Source + Support</strong>: Rilasciare il software gratuitamente ma vendere supporto, training e servizi personalizzati. Questo modello sta guadagnando trazione, soprattutto tra le aziende che vogliono mantenere il controllo sui propri dati.</p>
-
 <h2>Tendenze Tecnologiche Emergenti</h2>
-
 <h3>IA Multimodale: Oltre Testo e Immagini</h3>
-
 <p>Il futuro dell'IA va oltre le singole modalità. I modelli multimodali, capaci di processare testo, immagini, audio e video simultaneamente, stanno aprendo possibilità completamente nuove.</p>
-
 <p>GPT-4V (Vision) di OpenAI è stato uno dei primi modelli mainstream a combinare comprensione testuale e visiva in modo efficace. Ora possiamo fare domande su immagini, analizzare grafici complessi o persino ricevere aiuto per riparare oggetti mostrando semplicemente una foto del problema.</p>
-
 <p>Gemini Ultra di Google va ancora oltre, promettendo di processare video lunghi e audio complessi. Immagina di poter caricare una registrazione di una riunione di due ore e ricevere un riassunto dettagliato con action items specifici e analisi del sentiment dei partecipanti.</p>
-
-<p>Questa evoluzione verso l'IA multimodale riflette il modo in cui gli esseri umani processano naturalmente le informazioni: non limitiamo la nostra comprensione a un singolo senso, ma integriamo vista, udito e linguaggio per formare una comprensione completa del mondo.<br><br><br></p>
-
+<p>Questa evoluzione verso l'IA multimodale riflette il modo in cui gli esseri umani processano naturalmente le informazioni: non limitiamo la nostra comprensione a un singolo senso, ma integriamo vista, udito e linguaggio per formare una comprensione completa del mondo.<br/><br/><br/></p>
 <h3>Edge AI: Intelligenza Distribuita</h3>
-
 <p>Mentre i grandi modelli linguistici richiedono data center potenti, c'è una tendenza parallela verso l'Edge AI - portare l'intelligenza artificiale direttamente sui dispositivi che utilizziamo quotidianamente.</p>
-
 <p>Gli smartphone moderni incorporano chip specifici per l'IA che permettono funzionalità come il riconoscimento facciale, la fotografia computazionale e la traduzione in tempo reale senza dover inviare dati al cloud. Questo non solo migliora la privacy e riduce la latenza, ma rende l'IA accessibile anche in assenza di connettività internet.</p>
-
 <p>Tesla rappresenta l'esempio più avanzato di Edge AI automotive: ogni veicolo è essenzialmente un data center mobile che processa terabyte di dati dai sensori in tempo reale per prendere decisioni di guida critiche.</p>
-
 <p>La prossima frontiera è l'IoT intelligente: sensori industriali che possono diagnosticare problemi autonomamente, elettrodomestici che apprendono dalle nostre abitudini, città smart che ottimizzano il traffico e il consumo energetico in tempo reale.</p>
-
 <h3>IA Conversazionale Avanzata</h3>
-
 <p>L'IA conversazionale sta evolvendo da semplici chatbot a assistenti genuinamente intelligenti. La nuova generazione di modelli può mantenere contesti di conversazione molto più lunghi, ricordare preferenze individuali e sviluppare una comprensione sfumata della personalità umana.</p>
-
 <p>Il concetto di "memory" nell'IA conversazionale sta diventando più sofisticato. Non si tratta solo di ricordare cosa hai detto nella conversazione corrente, ma di costruire un profilo personalizzato delle tue preferenze, del tuo stile di comunicazione e delle tue esigenze specifiche.</p>
-
 <p>Anthropic ha introdotto concetti di "Constitutional AI" che permettono agli assistenti di avere principi etici coerenti e di spiegare il loro ragionamento. Questo rende l'interazione più trasparente e affidabile.</p>
-
-<p>La prossima evoluzione potrebbe includere IA conversazionale con voci sintetiche indistinguibili da quelle umane, capacità di comprensione emotiva avanzata e persino la possibilità di sviluppare personalità distinte per diversi contesti d'uso.<br><br><br></p>
-
+<p>La prossima evoluzione potrebbe includere IA conversazionale con voci sintetiche indistinguibili da quelle umane, capacità di comprensione emotiva avanzata e persino la possibilità di sviluppare personalità distinte per diversi contesti d'uso.<br/><br/><br/></p>
 <h2>Settori Verticali: L'IA Specializzata</h2>
-
 <h3>Healthcare AI: Rivoluzione Medica</h3>
-
 <p>L'intelligenza artificiale in sanità sta passando da proof-of-concept a implementazioni cliniche reali. I modelli IA sono ora capaci di diagnosticare alcune condizioni con accuratezza superiore ai medici specialisti, particolarmente nell'imaging medico.</p>
-
 <p>DeepMind's AlphaFold ha risolto il protein folding problem, accelerando potenzialmente la ricerca farmaceutica di decenni. Questo tipo di breakthrough dimostra come l'IA possa affrontare problemi fondamentali della scienza che hanno resistito a decenni di ricerca tradizionale.</p>
-
 <p>L'IA sta anche rivoluzionando la medicina personalizzata, analizzando genomi individuali per predire rischi di malattie e ottimizzare trattamenti. Immagina una medicina dove ogni trattamento è ottimizzato specificatamente per il tuo profilo genetico e la tua storia medica.</p>
-
 <h3>Finance AI: Oltre il Trading Algoritmico</h3>
-
 <p>Nel settore finanziario, l'IA va ben oltre i tradizionali algoritmi di trading. I modelli moderni possono analizzare sentiment dei mercati attraverso news e social media, rilevare frodi in tempo reale e fornire consulenza finanziaria personalizzata.</p>
-
 <p>Le banche stanno implementando IA conversazionale per customer service, ma anche per compliance e risk management. Un'IA può processare migliaia di documenti legali per identificare potenziali rischi normativi molto più velocemente di team di avvocati.</p>
-
 <p>L'assicurazione è un altro settore trasformato dall'IA: dai droni che valutano danni assicurativi all'analisi predittiva che può calcolare rischi individuali con precisione senza precedenti.</p>
-
 <h3>Education AI: Personalizzazione dell'Apprendimento</h3>
-
 <p>L'intelligenza artificiale in educazione sta creando esperienze di apprendimento veramente personalizzate. Invece del modello "one-size-fits-all", l'IA può adattare il contenuto, il ritmo e persino lo stile di insegnamento alle esigenze individuali di ogni studente.</p>
-
 <p>Khan Academy è pioniere dell'uso di IA per fornire tutoring personalizzato su scala globale. I loro sistemi possono identificare dove uno studente sta faticando e fornire esercizi mirati per rafforzare quelle specifiche competenze.</p>
-
 <p>L'IA sta anche rivoluzionando la ricerca accademica, aiutando ricercatori a navigare attraverso la letteratura scientifica in crescita esponenziale e identificare connessioni tra campi apparentemente non correlati.</p>
-
 <h2>Sfide e Considerazioni Etiche</h2>
-
 <h3>Il Problema della Black Box</h3>
-
 <p>Man mano che i modelli IA diventano più potenti, diventano anche più opachi. Un modello con centinaia di miliardi di parametri è essenzialmente una black box - sappiamo cosa entra e cosa esce, ma non possiamo facilmente spiegare perché prende certe decisioni.</p>
-
 <p>Questo è problematico in settori dove la spiegabilità è cruciale, come medicina e giustizia. Se un'IA raccomanda un trattamento medico o influenza una decisione legale, dobbiamo poter capire il ragionamento dietro quella decisione.</p>
-
 <p>La ricerca sull'Intelligenza Artificiale Spiegabile, (XAI) sta cercando di risolvere questo problema, sviluppando tecniche per rendere i modelli IA più interpretabili senza sacrificare le prestazioni.</p>
-
 <h3>Bias e Fairness</h3>
-
 <p>L'IA impara dai dati, e se quei dati riflettono bias umani, l'IA perpetuerà e potenzialmente amplificherà quei bias. Abbiamo visto esempi di sistemi di riconoscimento facciale che funzionano peggio su persone di colore, o algoritmi di assunzione che discriminano contro le donne.</p>
-
 <p>Affrontare i pregiudizi nell'IA richiede sforzi consapevoli durante tutto il pipeline di sviluppo: dalla collezione dati al design degli algoritmi al testing in diversi gruppi demografici.</p>
-
 <p>Alcune aziende stanno investendo significativamente in "AI fairness" ovvero equità nelle IA, sviluppando strumenti e processi per identificare e mitigare i bias. Tuttavia, questo rimane un problema complesso senza soluzioni semplici.</p>
-
 <h3>Privacy e Sicurezza dei Dati</h3>
-
 <p>I modelli IA moderni sono affamati di dati, e più dati hanno, meglio performano. Questo crea tensioni naturali con la privacy individuale. Come possiamo beneficiare del potenziale dell'IA mantenendo il controllo sui nostri dati personali?</p>
-
 <p>Tecniche come federated learning permettono di addestrare modelli su dati distribuiti senza centralizzarli. Differential privacy aggiunge rumore matematicamente calibrato per proteggere informazioni individuali mantenendo utilità statistica.</p>
-
 <p>Tuttavia, queste sono soluzioni tecniche a quello che è spesso un problema di governance e policy. Regolamentazioni come GDPR in Europa stanno iniziando a fornire frameworks legali, ma la velocità dell'innovazione IA spesso supera quella della regolamentazione.</p>
-
 <h3>L'Impatto sul Mercato del Lavoro</h3>
-
 <p>Una delle preoccupazioni più discusse riguardo l'IA è il suo potenziale impatto sull'occupazione. Mentre alcuni lavori potrebbero essere automatizzati, l'esperienza storica suggerisce che le rivoluzioni tecnologiche tendono a creare nuovi tipi di lavoro mentre ne eliminano altri.</p>
-
 <p>L'IA sta già creando nuove categorie professionali: prompt engineers, AI trainers, algorithm auditors. Allo stesso tempo, sta trasformando lavori esistenti piuttosto che semplicemente eliminarli. Un avvocato con accesso a strumenti di ricerca legale potenziati dall'IA può essere più efficace, non necessariamente sostituito.</p>
-
-<p>La chiave sarà l'adattabilità: sistemi educativi che preparano le persone per un mondo dove la collaborazione uomo-IA è la norma, e politiche che supportano la transizione lavorativa.<br><br><br><br><br><br><br><br><br><br></p>
-
+<p>La chiave sarà l'adattabilità: sistemi educativi che preparano le persone per un mondo dove la collaborazione uomo-IA è la norma, e politiche che supportano la transizione lavorativa.<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/></p>
 <h2>Il Futuro dell'Ecosistema IA</h2>
-
 <h3>Verso l'IA Generale (AGI)</h3>
-
-<p>L'obiettivo ultimo di molte di queste aziende è lo sviluppo di Artificial General Intelligence (AGI) - un'IA che può performare qualsiasi compito intellettuale umano. Mentre siamo ancora lontani da questo obiettivo, i progressi recenti suggeriscono che potremmo essere più vicini di quanto pensassimo.<br><br><br></p>
-
+<p>L'obiettivo ultimo di molte di queste aziende è lo sviluppo di Artificial General Intelligence (AGI) - un'IA che può performare qualsiasi compito intellettuale umano. Mentre siamo ancora lontani da questo obiettivo, i progressi recenti suggeriscono che potremmo essere più vicini di quanto pensassimo.<br/><br/><br/></p>
 <p>I modelli attuali mostrano già capacità emergenti sorprendenti: GPT-4 può ragionare attraverso problemi complessi, imparare nuovi compiti da pochi esempi, e persino mostrare creatività in domini come arte e musica. Tuttavia, queste capacità sono ancora limitate e dipendenti dal contesto.</p>
-
 <p>La strada verso l'AGI probabilmente richiederà una svolta in diverse aree: ragionamento simbolico, apprendimento continuo, trasferimento dell'apprendimento tra materie diverse, e integrazione di iverse modalità cognitive.</p>
-
 <h3>Democratizzazione vs Concentrazione</h3>
-
 <p>Una sfida interessante nell'ecosistema IA è tra democratizzazione e concentrazione. Da una parte, strumenti open-source e cloud services stanno rendendo l'IA più accessibile che mai. Dall'altra, i modelli più avanzati richiedono risorse computazionali massive che solo poche aziende possono permettersi.</p>
-
 <p>Questo sta creando un ecosistema stratificato: modelli open-source per applicazioni comuni e sperimentazione, modelli proprietari per capacità all'avanguardia. La sfida sarà mantenere innovazione accessibile garantendo al tempo stesso che i benefici dell'IA siano ampiamente distribuiti.</p>
-
 <h3>Convergenza Tecnologica</h3>
-
 <p>Il futuro dell'IA probabilmente vedrà convergenza con altre tecnologie emergenti. I computer quantistici potrebbero accelerare certi tipi di addestramento AI. Le biotecnologie potrebbero beneficiare enormemente da scoperte farmaceutiche dell'AI. L'Internet delle cose potrebbe creare vaste reti di sensori intelligenti.</p>
-
-<p><br><br>Le interfacce cervello-computer rappresentano forse l'ultima convergenza: l'integrazione diretta tra cognizione umana e intelligenza artificiale. Aziende come Neuralink stanno già lavorando per raggiungere questo obiettivo, anche se le applicazioni pratiche sono ancora lontane anni.</p>
-
+<p><br/><br/>Le interfacce cervello-computer rappresentano forse l'ultima convergenza: l'integrazione diretta tra cognizione umana e intelligenza artificiale. Aziende come Neuralink stanno già lavorando per raggiungere questo obiettivo, anche se le applicazioni pratiche sono ancora lontane anni.</p>
 <h2>Strategie per Imprese e Sviluppatori</h2>
-
 <h3>Per le Aziende: Come Navigare l'IA</h3>
-
 <p>Per le aziende che guardano all'IA, la strategia dovrebbe essere pragmatica piuttosto che guidata dal marketing. Invece di cercare di implementare l'IA più avanzata disponibile, le aziende dovrebbero essere concetrate su casi d'uso specifici dove l'IA può fornire un chiaro valore.</p>
-
 <p>Inizia in piccolo: identifica i processi che sono ricchi di dati ma ad alta intensità di lavoro. Il servizio clienti, l'elaborazione dei documenti e la manutenzione predittiva sono spesso buoni punti di partenza. Utilizzare i servizi cloud esistenti invece di costruirli da zero: questo permette di provare l'IA senza massicci investimenti iniziali.</p>
-
 <p>L'investimento nell'infrastruttura dei dati è cruciale. La qualità dei dati determina in gran parte il successo di qualsiasi iniziativa di intelligenza artificiale. Le aziende che hanno investito in una buona governance dei dati negli scorsi anni stanno ora raccogliendo i frutti nell'era dell'IA.</p>
-
 <p>Altrettanto importanti sono la formazione e la gestione del cambiamento. L'IA non è solo implementazione tecnologica ma trasformazione aziendale. I dipendenti devono capire quando lavorano con gli strumenti di intelligenza artificiale, non solo usarli.</p>
-
 <h3>Per Sviluppatori: Costruire Carriere nell'IA</h3>
-
 <p>Per sviluppatori interessati nell'IA, il panorama offre opportunità senza precedenti ma richiede anche apprendimento continuo. Le competenze più preziose combinano competenza tecnica con competenza di dominio.</p>
-
-<p><br><br>La comprensione dei fondamenti rimane importante: algebra lineare, statistica e competenze di programmazione sono fondamentali. Tuttavia, con strumenti sempre più accessibili, la capacità di tradurre i problemi aziendali in soluzioni di intelligenza artificiale è sempre più preziosa.</p>
-
+<p><br/><br/>La comprensione dei fondamenti rimane importante: algebra lineare, statistica e competenze di programmazione sono fondamentali. Tuttavia, con strumenti sempre più accessibili, la capacità di tradurre i problemi aziendali in soluzioni di intelligenza artificiale è sempre più preziosa.</p>
 <p>La specializzazione può essere più preziosa della generalizzazione. Invece di cercare di essere esperti in tutte le tecniche di intelligenza artificiale, considerate di concentrarvi su domini specifici (intelligenza artificiale sanitaria, intelligenza artificiale fintech, ecc.) o su specifici tipi di modelli (visione artificiale, PNL, ecc.).</p>
-
 <p>Il contributo open source è un ottimo modo per costruire una reputazione nella comunità dell'IA. Piattaforme come Hugging Face, GitHub e Kaggle offrono opportunità per mettere in mostra le proprie competenze e collaborare con altri.</p>
-
 <h2>Case Studies: Successi e Fallimenti</h2>
-
 <h3>Successo: Netflix e Recommendation Systems</h3>
-
 <p>Netflix ha costruito il suo business attorno alle raccomandazioni basate sull'intelligenza artificiale. Il loro sistema analizza la cronologia delle visualizzazioni, il comportamento degli utenti e le caratteristiche dei contenuti per prevedere cosa gli utenti vogliono vedere in seguito. Questo non è solo convenienza: è fondamentale per il business. Netflix stima che il loro sistema di raccomandazione faccia risparmiare oltre 1 miliardo di dollari all'anno in termini di abbandono ridotto.</p>
-
-<p>Il successo di Netflix dimostra l'importanza di allineare le capacità dell'intelligenza artificiale con gli obiettivi aziendali. Non hanno provato a costruire l'intelligenza artificiale più sofisticata possibile; si sono concentrati molto bene sulla risoluzione di uno specifico problema aziendale.<br><br><br><br><br><br><br><br></p>
-
+<p>Il successo di Netflix dimostra l'importanza di allineare le capacità dell'intelligenza artificiale con gli obiettivi aziendali. Non hanno provato a costruire l'intelligenza artificiale più sofisticata possibile; si sono concentrati molto bene sulla risoluzione di uno specifico problema aziendale.<br/><br/><br/><br/><br/><br/><br/><br/></p>
 <h3>Lezione: IBM Watson in ambito sanitario</h3>
-
 <p>IBM Watson Health aveva promesso di rivoluzionare il trattamento del cancro utilizzando l'intelligenza artificiale per analizzare la letteratura medica e i dati dei pazienti. Tuttavia, il progetto non è riuscito a mantenere le promesse. Watson ha incontrato difficoltà a causa della complessità medica, dei problemi di qualità dei dati e della mancanza di dati di addestramento sufficienti.</p>
-
 <p>Questo caso illustra l'importanza di aspettative realistiche e di una corretta definizione del problema. Il settore sanitario è uno dei settori più impegnativi per l'intelligenza artificiale, che richiede non solo sofisticatezza tecnica, ma anche una profonda comprensione della pratica medica e delle normative.</p>
-
 <h3>Emergente: Guida completamente autonoma di Tesla</h3>
-
 <p>L'approccio di Tesla alla guida autonoma è controverso ma istruttivo. Invece di utilizzare costosi sensori LiDAR come la maggior parte dei concorrenti, Tesla si affida a un approccio basato solo su telecamere e reti neurali.</p>
-
 <p>Sebbene la guida completamente autonoma non sia ancora completamente autonoma, Tesla ha accumulato milioni di chilometri di dati di guida reali che le conferiscono un potenziale vantaggio competitivo. Il loro approccio dimostra come diverse strategie tecniche possano portare allo stesso obiettivo.</p>
-
 <h2>Implicazioni Geopolitiche e Economiche</h2>
-
 <h3>La Corsa all'IA tra Nazioni</h3>
-
 <p>L'intelligenza artificiale è diventata una priorità strategica nazionale per molti paesi. Gli Stati Uniti dominano attualmente in termini di investimenti privati ​​e talento, ma la Cina sta rapidamente recuperando terreno rispetto a significativi investimenti pubblici.</p>
-
 <p>L'Europa si concentra sulla regolamentazione dell'IA e sugli standard etici, posizionandosi come leader nello sviluppo responsabile dell'IA. Questo diverso approccio potrebbe creare vantaggi competitivi in ​​settori in cui fiducia e conformità sono critici.</p>
-
 <p>Il controllo dell'AI supply chain è diventato geopoliticamente importante. Le restrizioni sui semiconduttori, le politiche sulla migrazione dei talenti e le normative sulla governance dei dati stanno tutti plasmando il panorama globale dell’intelligenza artificiale.</p>
-
 <h3>Impatto Macro Economico</h3>
-
 <p>Si prevede che l'IA contribuirà all'economia globale nel prossimo decennio. Tuttavia, i benefici potrebbero essere distribuiti in modo non uniforme, aumentando potenzialmente la disuguaglianza sia all'interno che all'esterno dei Paesi.</p>
-
 <p>I settori che integrano con successo l'IA in tempi rapidi potrebbero ottenere vantaggi competitivi sostenibili. Ciò crea pressioni per una rapida adozione, ma anche rischi di un'implementazione prematura.</p>
-
 <p>È probabile che si verifichi una perturbazione del mercato del lavoro, ma storicamente le rivoluzioni tecnologiche hanno creato più posti di lavoro di quanti ne abbiano distrutti. La sfida sarà garantire che i lavoratori disoccupati possano passare a nuovi ruoli.</p>
-
 <h2>Conclusioni: Navigare il Futuro dell'IA</h2>
-
 <p>Mentre concludiamo questo viaggio attraverso il panorama dell'intelligenza artificiale del 2025, emerge chiaramente che siamo testimoni di una delle trasformazioni tecnologiche più significative della storia umana. Le aziende leader del settore non stanno semplicemente sviluppando prodotti migliori; stanno ridefinendo cosa significa essere intelligenti nell'era digitale.</p>
-
 <p>I numeri parlano chiaro: con investimenti che superano i 75 miliardi di dollari per la sola Microsoft e una crescita del settore che continua a un ritmo senza precedenti, l'IA non è più una tecnologia del futuro ma una realtà del presente che permea ogni aspetto della nostra vita quotidiana e lavorativa.</p>
-
 <p>Quello che rende questo momento particolarmente affascinante è la democratizzazione parallela che sta avvenendo. Mentre giganti come OpenAI, Google e Microsoft competono per sviluppare i modelli più avanzati, strumenti come Hugging Face, TensorFlow e servizi cloud rendono l'IA accessibile a chiunque abbia un'idea e la determinazione per realizzarla. Uno studente universitario oggi ha accesso a strumenti IA che erano impensabili anche per le più grandi aziende tecnologiche di appena dieci anni fa.</p>
-
-<p><br><br>Le tendenze emergenti che abbiamo esplorato - dall'IA multimodale all'edge computing, dalla specializzazione verticale all'integrazione cross-platform - suggeriscono che siamo solo all'inizio di questa rivoluzione. Ogni svolta tecnica apre nuove possibilità che sembravano fantascienza fino a ieri: assistenti veramente intelligenti che comprendono contesto e emozioni, sistemi di diagnosi medica più accurati dei migliori specialisti, auto che guidano meglio degli umani.</p>
-
+<p><br/><br/>Le tendenze emergenti che abbiamo esplorato - dall'IA multimodale all'edge computing, dalla specializzazione verticale all'integrazione cross-platform - suggeriscono che siamo solo all'inizio di questa rivoluzione. Ogni svolta tecnica apre nuove possibilità che sembravano fantascienza fino a ieri: assistenti veramente intelligenti che comprendono contesto e emozioni, sistemi di diagnosi medica più accurati dei migliori specialisti, auto che guidano meglio degli umani.</p>
 <p>Tuttavia, da un grande potere deriva una grande responsabilità. Le sfide etiche che abbiamo discusso - bias algoritmici, privacy dei dati, trasparenza delle decisioni, impatto sull'occupazione - non sono ostacoli tecnici da superare, ma questioni fondamentali che definiranno che tipo di futuro stiamo costruendo. La differenza tra un'IA che amplifica il meglio dell'umanità e una che perpetua le nostre peggiori tendenze risiede nelle scelte che facciamo oggi.</p>
-
 <p>L'ecosistema competitivo del 2025 dimostra che non esiste una singola strada verso l'intelligenza artificiale avanzata. L'approccio "safety-first" di Anthropic, la trasparenza radicale promessa da xAI, l'integrazione enterprise di Microsoft, l'apertura scientifica di Meta con Llama - ogni strategia rappresenta una diversa visione di come l'IA dovrebbe evolvere e integrarsi nella società.</p>
-
 <p>Per le aziende, il messaggio è chiaro: l'IA non è più un'opzione ma una necessità competitiva. Tuttavia, il successo non deriverà dall'adozione dell'ultimo modello più avanzato, ma dalla capacità di identificare dove l'IA può creare valore reale e implementarla in modo ponderato e strategico. Netflix con i suoi sistemi di raccomandazione e Tesla con la guida autonoma dimostrano che spesso vince chi applica l'IA in modo mirato e coerente con i propri obiettivi di business.</p>
-
 <p>Per gli sviluppatori e i professionisti, questo è simultaneamente il momento più eccitante e sfidante della storia dell'informatica. Le competenze tecniche rimangono importanti, ma ciò che diventa sempre più prezioso è la capacità di fare da ponte tra possibilità tecniche e bisogni umani reali. Il futuro appartiene a chi sa combinare competenza tecnica con comprensione del dominio, creatività con rigore scientifico.</p>
-
 <p>Guardando avanti, possiamo aspettarci che il ritmo dell'innovazione continui ad accelerare. I modelli linguistici diventeranno più potenti e specializzati, l'IA multimodale aprirà nuove interfacce di interazione, l'edge computing porterà intelligenza ovunque. Ma forse la trasformazione più profonda sarà culturale: impareremo a collaborare con l'intelligenza artificiale come partner, non come strumento.</p>
-
-<p><br><br><br>La strada verso l'intelligenza artificiale generale rimane incerta e piena di sfide tecniche e filosofiche profonde. Ma ogni passo di questo viaggio sta già trasformando il mondo attorno a noi. Dalle aule scolastiche agli ospedali, dai laboratori di ricerca alle catene di montaggio, l'IA sta diventando il tessuto connettivo invisibile che potenzia le capacità umane.</p>
-
+<p><br/><br/><br/>La strada verso l'intelligenza artificiale generale rimane incerta e piena di sfide tecniche e filosofiche profonde. Ma ogni passo di questo viaggio sta già trasformando il mondo attorno a noi. Dalle aule scolastiche agli ospedali, dai laboratori di ricerca alle catene di montaggio, l'IA sta diventando il tessuto connettivo invisibile che potenzia le capacità umane.</p>
 <p>Il panorama dell'IA del 2025 ci insegna che il futuro non sarà determinato dalla tecnologia più avanzata, ma da come scegliamo di usarla. Le aziende e gli strumenti che abbiamo esplorato sono i mattoni con cui stiamo costruendo questo futuro. Spetta a noi - sviluppatori, imprenditori, policymaker, cittadini - assicurarci che sia un futuro di cui possiamo essere orgogliosi.</p>
-
 <p>L'intelligenza artificiale non è più una promessa del domani: è la realtà di oggi che sta plasmando il mondo di domani. E mentre continuiamo a navigare questa trasformazione epocale, una cosa è certa: il viaggio è appena iniziato, e le possibilità sono limitate solo dalla nostra immaginazione e dalla nostra saggezza nell'utilizzarle.</p>
 
             <div class="footer-back-button">

--- a/dist/06-AI Valutazione ed Etica.html
+++ b/dist/06-AI Valutazione ed Etica.html
@@ -162,312 +162,159 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>Valutare l'Intelligenza Artificiale: Quando i Numeri Incontrano l'Etica</h1>
-
 <p><em>di Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="Leonardo_Phoenix_An_ethically_charged_portrait_of_AIs_challeng_0.jpg" alt="Leonardo_Phoenix_An_ethically_charged_portrait_of_AIs_challeng_0.jpg" /></p>
-
+<img alt="Leonardo_Phoenix_An_ethically_charged_portrait_of_AIs_challeng_0.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/06-AI Valutazione ed Etica/Leonardo_Phoenix_An_ethically_charged_portrait_of_AIs_challeng_0.jpg"/></p>
 <p><em>Negli scorsi cinque articoli abbiamo esplorato insieme il mondo dell'intelligenza artificiale partendo dalle sue radici storiche e dai fondamenti tecnologici, per poi addentrarci nelle complessità del machine learning e del deep learning. Abbiamo visto come l'AI stia trasformando il mondo del lavoro e dello studio, scoperto le meraviglie dell'AI generativa che crea immagini, testi e video, e analizzato il panorama delle aziende e degli strumenti che stanno plasmando questo settore.</em></p>
-
 <p><em>Ora, in questo ultimo capitolo del nostro viaggio, affrontiamo forse la questione più delicata e cruciale: come facciamo a sapere se un sistema di intelligenza artificiale funziona davvero bene? E soprattutto, come possiamo assicurarci che funzioni in modo etico e responsabile?</em></p>
-
 <p><em>È una domanda che diventa sempre più pressante mentre l'AI si diffonde in ogni aspetto della nostra vita. Non basta più che un sistema "sembri" intelligente – dobbiamo essere in grado di misurarne le prestazioni, capirne i limiti e garantire che operi secondo principi etici condivisi.</em></p>
-
 <h2>Oltre il Test di Turing: La Nuova Frontiera della Valutazione</h2>
-
 <p>Il famoso Test di Turing, proposto dal matematico britannico Alan Turing nel 1950, rappresentava una sfida affascinante: una macchina poteva dirsi intelligente se riusciva a ingannare un giudice umano durante una conversazione, facendogli credere di essere anch'essa umana. Per decenni, questo test è stato il punto di riferimento per misurare l'intelligenza artificiale.</p>
-
 <p>Oggi, però, il Test di Turing ci appare quasi anacronistico. I moderni sistemi di intelligenza artificiale conversazionale come ChatGPT, Claude o Gemini potrebbero facilmente superarlo, eppure nessuno si sognerebbe di affermare che abbiano raggiunto una vera intelligenza generale. Il test misura solo la capacità di imitazione, non la comprensione profonda o la capacità di ragionamento.</p>
-
 <p>È per questo che la comunità scientifica ha sviluppato una nuova generazione di strumenti di valutazione: i <strong>benchmark</strong>. Questi non sono semplici test, ma veri e propri ecosistemi di valutazione che misurano capacità specifiche in modo oggettivo e riproducibile.</p>
-
 <h2>I Benchmark Moderni: Misurare l'Intelligenza Pezzo per Pezzo</h2>
-
 <h3>FrontierMath: La Matematica Come Banco di Prova</h3>
-
 <p>Uno dei benchmark più interessanti sviluppati di recente è <strong>FrontierMath</strong>, che rappresenta una vera rivoluzione nel modo di testare le capacità di ragionamento matematico dell'AI. A differenza dei tradizionali test matematici, FrontierMath presenta problemi completamente originali, progettati da matematici esperti per essere impegnativi anche per i professionisti del settore.</p>
-
-<p>La genialità di questo approccio sta nella sua incontestabilità: un problema matematico ha una soluzione precisa, verificabile automaticamente. Non c'è spazio per interpretazioni soggettive o bias di valutazione. Quando un sistema di AI risolve correttamente un teorema complesso di teoria dei numeri, il risultato parla da solo.<br><br></p>
-
+<p>La genialità di questo approccio sta nella sua incontestabilità: un problema matematico ha una soluzione precisa, verificabile automaticamente. Non c'è spazio per interpretazioni soggettive o bias di valutazione. Quando un sistema di AI risolve correttamente un teorema complesso di teoria dei numeri, il risultato parla da solo.<br/><br/></p>
 <h3>ARC: Il Test del Ragionamento Fluido</h3>
-
 <p>L'<strong>ARC Benchmark</strong> (Abstraction and Reasoning Corpus) adotta un approccio diverso ma altrettanto rigoroso. Presentando pattern visivi che richiedono ragionamento astratto, ARC cerca di misurare quella che i psicologi chiamano "intelligenza fluida" – la capacità di affrontare problemi completamente nuovi senza fare affidamento su conoscenze pregresse.</p>
-
 <p>È un test che anche i bambini possono risolvere intuitivamente, ma che mette in difficoltà i più sofisticati sistemi di AI. Questo paradosso ci ricorda che l'intelligenza non è solo accumulo di informazioni, ma capacità di adattamento e innovazione.</p>
-
 <h3>La Convergenza delle Prestazioni: Un Fenomeno del 2025</h3>
-
 <p>Uno dei trend più significativi emersi nel 2025 è la rapida convergenza delle prestazioni tra i diversi modelli di AI. Secondo il rapporto AI Index 2025 di Stanford, la differenza di punteggio Elo tra il primo e il decimo modello nella Chatbot Arena Leaderboard si è ridotta dall'11,9% del 2024 al solo 5,4% del 2025. </p>
-
 <p>Ancora più sorprendente è la riduzione del gap tra modelli statunitensi e cinesi: se nel gennaio 2024 i migliori modelli americani superavano quelli cinesi del 9,26%, entro febbraio 2025 questa differenza era scesa a solo l'1,70%. L'arrivo di DeepSeek-R1 ha ulteriormente accorciato le distanze, dimostrando che l'eccellenza nell'AI non è più monopolio di poche aziende occidentali.</p>
-
-<p>Questo fenomeno ha implicazioni profonde: stiamo assistendo alla democratizzazione dell'AI di alta qualità? O ci stiamo avvicinando a un plateau nelle prestazioni che richiederà approcci completamente nuovi per progredire ulteriormente?<br><br><br><br><br><br><br><br><br><br></p>
-
+<p>Questo fenomeno ha implicazioni profonde: stiamo assistendo alla democratizzazione dell'AI di alta qualità? O ci stiamo avvicinando a un plateau nelle prestazioni che richiederà approcci completamente nuovi per progredire ulteriormente?<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/></p>
 <h2>Oltre i Numeri: Le Metriche che Contano Davvero</h2>
-
 <h3>Accuratezza, Precisione e il Delicato Equilibrio delle Metriche</h3>
-
 <p>Quando valutiamo un sistema di AI, i numeri raccontano solo parte della storia. L'<strong>accuratezza</strong> – la percentuale di previsioni corrette – può sembrare l'indicatore definitivo, ma nasconde insidie pericolose. Un sistema che diagnostica malattie rare con il 99% di accuratezza potrebbe sembrare eccellente, ma se quella percentuale deriva dal fatto che dice sempre "non malato" (corretto nel 99% dei casi perché la malattia è rara), in realtà è completamente inutile.</p>
-
 <p>È qui che entrano in gioco metriche più sofisticate come la <strong>precisione</strong> (quante delle diagnosi positive sono corrette?) e il <strong>richiamo</strong> (quanti dei casi positivi reali sono stati identificati?). L'<strong>F1-score</strong>, che bilancia questi due aspetti, offre una visione più completa delle prestazioni.</p>
-
 <h3>La Sfida dell'Usabilità: Quando l'AI Incontra l'Umano</h3>
-
 <p>Ma anche le metriche più sofisticate non catturano un aspetto cruciale: l'usabilità. Un sistema di AI può essere tecnicamente perfetto ma completamente inutilizzabile nella pratica. È come avere un'auto da Formula 1 per andare a fare la spesa: tecnicamente superiore, praticamente inadeguata.</p>
-
 <p>La valutazione dell'usabilità richiede approcci più umani: test con utenti reali, questionari di soddisfazione, analisi dei pattern di utilizzo. Microsoft Research ha recentemente sviluppato nuove metodologie che vanno oltre la semplice misurazione dell'accuratezza, valutando le conoscenze e le capacità cognitive richieste da un compito e confrontandole con le capacità effettive del modello.</p>
-
 <h2>L'Interpretabilità: Aprire la Scatola Nera</h2>
-
 <p>Una delle sfide più affascinanti della valutazione dell'AI riguarda l'interpretabilità. I moderni sistemi di deep learning sono spesso descritti come "scatole nere" – funzionano, ma non sappiamo esattamente come o perché prendono certe decisioni.</p>
-
 <p>Questo non è solo un problema accademico. Immaginate di essere un medico che deve spiegare a un paziente perché l'AI ha suggerito una certa terapia, o un giudice che deve giustificare una sentenza basata su raccomandazioni algoritmiche. Il "perché" diventa altrettanto importante del "cosa".</p>
-
 <h3>LIME e SHAP: Illuminare l'Oscurità Algoritmica</h3>
-
 <p>Strumenti come <strong>LIME</strong> (Local Interpretable Model-agnostic Explanations) e <strong>SHAP</strong> (SHapley Additive exPlanations) rappresentano tentativi sofisticati di rispondere a questa esigenza. LIME funziona come un detective algoritmico: analizza piccole variazioni nell'input per capire quali elementi influenzano maggiormente una decisione. SHAP, invece, prende in prestito concetti dalla teoria dei giochi per distribuire equamente il "credito" di una previsione tra tutte le caratteristiche di input.</p>
-
 <p>Questi strumenti non sono perfetti – offrono spiegazioni approssimate, non verità assolute – ma rappresentano passi importanti verso un'AI più trasparente e responsabile.</p>
-
 <h2>La Dimensione Etica: Quando i Numeri Non Bastano</h2>
-
 <h3>Il Bias: Il Nemico Silenzioso</h3>
-
 <p>Nessuna discussione sulla valutazione dell'AI può ignorare la questione del bias. I sistemi di intelligenza artificiale imparano dai dati, e se questi dati riflettono pregiudizi e disuguaglianze della società, l'AI li amplificherà e li perpetuerà.</p>
-
 <p>Il bias nell'AI non è solo un problema tecnico da risolvere, ma uno specchio delle nostre società. Quando un sistema di selezione del personale discrimina contro le donne, non sta "sbagliando" in senso tecnico – sta riflettendo pattern reali presenti nei dati storici di assunzione. La sfida è distinguere tra pattern utili e pregiudizi inaccettabili.</p>
-
 <h3>Nuovi Strumenti per la Valutazione Etica</h3>
-
 <p>Fortunatamente, la comunità dell'AI sta sviluppando strumenti sempre più sofisticati per identificare e mitigare questi problemi. Nuovi benchmark come HELM Safety, AIR-Bench e FACTS offrono strumenti promettenti per valutare la fattualità e la sicurezza dei sistemi di AI.</p>
-
 <p>Strumenti come AIF360 valutano l'equità attraverso diverse metriche, come l'impatto disparato e la parità statistica, permettendo una ricalibratura continua dei modelli per mantenere prestazioni etiche. Questi sistemi rappresentano un approccio proattivo all'etica dell'AI, incorporando considerazioni etiche fin dalle fasi iniziali di sviluppo.</p>
-
 <h2>La Sfida della Contaminazione dei Dati</h2>
-
 <p>Una delle questioni più spinose nella valutazione moderna dell'AI è la <strong>contaminazione dei dati</strong>. Cosa succede quando un modello ha già "visto" le domande del test durante il suo addestramento? È come permettere a uno studente di consultare le risposte durante un esame.</p>
-
 <p>Studi recenti mostrano che questa pratica è più diffusa di quanto si pensasse: su 30 modelli analizzati nell'ottobre 2024, solo 9 hanno riportato informazioni sulla sovrapposizione tra dati di addestramento e test. Questo problema non mina solo l'affidabilità dei benchmark, ma solleva questioni più profonde sulla trasparenza e l'onestà nella ricerca sull'AI.</p>
-
 <h2>L'Evoluzione dei Benchmark: Verso Test Più Realistici</h2>
-
 <h3>Dai Laboratori al Mondo Reale</h3>
-
 <p>I benchmark tradizionali spesso valutano capacità isolate in condizioni artificiali. Ma l'AI del futuro dovrà operare nel mondo reale, dove i problemi sono disordinati, incompleti e interconnessi.</p>
-
-<p>Nuovi benchmark stanno emergendo per testare la velocità di esecuzione delle applicazioni AI, incluso uno basato sul modello Llama 3.1 da 405 miliardi di parametri di Meta, che testa la capacità di un sistema di processare query complesse e sintetizzare dati. Questi test riflettono una maturazione del settore, che si sta spostando dalla ricerca pura verso applicazioni pratiche.<br><br><br><br><br><br><br></p>
-
+<p>Nuovi benchmark stanno emergendo per testare la velocità di esecuzione delle applicazioni AI, incluso uno basato sul modello Llama 3.1 da 405 miliardi di parametri di Meta, che testa la capacità di un sistema di processare query complesse e sintetizzare dati. Questi test riflettono una maturazione del settore, che si sta spostando dalla ricerca pura verso applicazioni pratiche.<br/><br/><br/><br/><br/><br/><br/></p>
 <h3>L'Era degli Agenti AI</h3>
-
 <p>Il 2025 ha visto l'emergere di sistemi AI sempre più "agentici" – capaci cioè di agire autonomamente nell'ambiente per raggiungere obiettivi complessi. Il focus si sta spostando verso la creazione di prodotti rivolti ai clienti e lo sviluppo di flussi di lavoro agentici complessi, richiedendo nuovi tipi di valutazione che vadano oltre le metriche tradizionali.</p>
-
 <p>Come si valuta un agente AI che deve coordinare diverse attività, adattarsi a situazioni impreviste e interagire con sistemi e persone diverse? È una sfida che richiede approcci completamente nuovi alla valutazione.</p>
-
 <h2>Voci dal Mondo: Cosa Dicono i Grandi Pensatori dell'AI</h2>
-
 <h3>La Ridefinizione dell'Essere Umano: Harari e la Sfida dell'Unicità</h3>
-
 <p>Yuval Noah Harari, lo storico israeliano diventato uno dei più influenti pensatori contemporanei, ha posto una domanda che dovrebbe farci riflettere profondamente: cosa significa essere umani nell'era dell'intelligenza artificiale? Nel suo libro <em>"21 lezioni per il XXI secolo"</em>, Harari evidenzia come l'AI stia sfidando la nostra comprensione tradizionale dell'unicità umana.</p>
-
 <p>"Non è più sufficiente definirci attraverso l'intelligenza o la capacità di apprendimento", scrive Harari, "poiché le macchine stanno dimostrando di poter eccellere in questi ambiti." Un esempio quotidiano di questa realtà lo viviamo tutti: i sistemi di raccomandazione di Netflix o Amazon spesso prevedono le nostre preferenze meglio di quanto facciamo noi stessi. Questo solleva domande fondamentali sulla nostra autoconsapevolezza e su come l'AI stia ridefinendo il concetto stesso di individualità.</p>
-
 <h3>La Questione della Coscienza: Chalmers e il Mistero della Mente Artificiale</h3>
-
 <p>Il filosofo australiano David Chalmers ha portato il dibattito su un piano ancora più profondo nel suo lavoro <em>"Reality+"</em>, ponendo domande sulla possibilità che le AI sviluppino una forma di coscienza. Chalmers esplora la possibilità che le esperienze delle AI possano essere qualitativamente diverse dalle nostre, ma ugualmente valide dal punto di vista fenomenologico.</p>
-
 <p>"Se un'AI fosse cosciente", si chiede Chalmers, "quali diritti dovremmo riconoscerle?" Non è una domanda puramente accademica. Molte persone sviluppano già un attaccamento emotivo verso assistenti virtuali come Siri, Alexa o ChatGPT, trattandoli con una cortesia che suggerisce una naturale tendenza umana ad antropomorfizzare le macchine. Questa tendenza ci pone di fronte a nuove sfide etiche e psicologiche che la valutazione tradizionale dell'AI fatica a catturare.</p>
-
 <h3>L'Impatto Sociale: Turkle e la Trasformazione delle Relazioni</h3>
-
 <p>Sherry Turkle, psicologa del MIT e una delle voci più autorevoli sullo studio dell'impatto delle tecnologie digitali, ha dedicato decenni alla comprensione di come l'AI stia modificando le relazioni umane. Nel suo influente <em>"Alone Together"</em>, Turkle evidenzia un paradosso della nostra epoca: mai così connessi tecnologicamente, mai così soli emotivamente.</p>
-
 <p>Un esempio concreto di questa trasformazione lo vediamo nelle app di dating, dove algoritmi decidono le nostre potenziali compatibilità romantiche, modificando radicalmente il tradizionale processo di formazione delle relazioni umane. "Stiamo delegando alle macchine non solo i calcoli", osserva Turkle, "ma anche l'intimità e la comprensione emotiva."</p>
-
 <h3>La Preservazione dell'Umanità: Nussbaum e le Capacità Fondamentali</h3>
-
 <p>Martha Nussbaum, filosofa americana e premio Principe delle Asturie, sottolinea l'importanza cruciale di mantenere e coltivare le capacità umane fondamentali nell'era dell'AI. Le sue riflessioni ci ricordano che mentre automatizziamo sempre più aspetti della nostra vita, dobbiamo preservare quelle qualità unicamente umane come l'empatia, la creatività e il pensiero critico.</p>
-
-<p>"L'educazione non deve prepararci solo a convivere con l'AI", argomenta Nussbaum, "ma a rimanere pienamente umani nonostante l'AI." È un monito che ha implicazioni dirette per come valutiamo i sistemi di intelligenza artificiale: non basta che funzionino bene tecnicamente, devono anche preservare e potenziare la nostra umanità.<br><br><br><br><br></p>
-
+<p>"L'educazione non deve prepararci solo a convivere con l'AI", argomenta Nussbaum, "ma a rimanere pienamente umani nonostante l'AI." È un monito che ha implicazioni dirette per come valutiamo i sistemi di intelligenza artificiale: non basta che funzionino bene tecnicamente, devono anche preservare e potenziare la nostra umanità.<br/><br/><br/><br/><br/></p>
 <h3>La Trasformazione Cognitiva: Carr e il Cervello Digitale</h3>
-
 <p>Nicholas Carr, nel suo rivoluzionario <em>"The Shallows: What the Internet Is Doing to Our Brains"</em>, offre una prospettiva illuminante su come l'AI stia modificando non solo il modo in cui pensiamo, ma la struttura stessa del nostro cervello. Carr argomenta che la costante esposizione agli algoritmi e all'automazione sta alterando i nostri processi cognitivi, riducendo la nostra capacità di concentrazione profonda e di pensiero contemplativo.</p>
-
 <p>Un esempio pratico che tutti riconosciamo: quando leggiamo online, bombardati da collegamenti ipertestuali e notifiche, il nostro cervello sviluppa un modello di lettura "a saltelli", perdendo la capacità di immergersi profondamente in un testo. "Stiamo diventando più efficienti nell'elaborazione superficiale delle informazioni", scrive Carr, "ma a scapito della nostra capacità di riflessione profonda."</p>
-
 <p>Carr non propone una critica nostalgica del passato, ma ci invita a riflettere consapevolmente su come l'integrazione con l'AI stia creando una nuova forma di cognizione ibrida. La sua analisi ci porta a una domanda fondamentale che dovrebbe guidare ogni valutazione dell'AI: mentre ci affidiamo sempre più all'intelligenza artificiale per attività cognitive, stiamo perdendo capacità mentali essenziali che hanno caratterizzato l'evoluzione umana per millenni?</p>
-
 <h3>Voci Critiche: Lanier e il Pensiero Critico a Rischio</h3>
-
 <p>Jaron Lanier, pioniere della realtà virtuale e uno dei critici più lucidi della tecnologia contemporanea, solleva preoccupazioni cruciali nel suo <em>"Ten Arguments for Deleting Your Social Media Accounts Right Now"</em>. Lanier evidenzia come gli algoritmi di AI che gestiscono i social media stiano influenzando non solo cosa pensiamo, ma come pensiamo.</p>
-
-<p>"Gli algoritmi non si limitano a mostrarci contenuti", avverte Lanier, "stanno modificando i nostri processi cognitivi." Un esempio quotidiano sono i feed personalizzati che creano "bolle informative", limitando la nostra esposizione a punti di vista diversi e riducendo la nostra capacità di pensiero critico. Questo ha implicazioni dirette per la valutazione dell'AI: non possiamo limitarci a misurare l'accuratezza tecnica, dobbiamo valutare anche l'impatto cognitivo e sociale.<br><br><br><br></p>
-
+<p>"Gli algoritmi non si limitano a mostrarci contenuti", avverte Lanier, "stanno modificando i nostri processi cognitivi." Un esempio quotidiano sono i feed personalizzati che creano "bolle informative", limitando la nostra esposizione a punti di vista diversi e riducendo la nostra capacità di pensiero critico. Questo ha implicazioni dirette per la valutazione dell'AI: non possiamo limitarci a misurare l'accuratezza tecnica, dobbiamo valutare anche l'impatto cognitivo e sociale.<br/><br/><br/><br/></p>
 <h3>L'Allineamento ai Valori Umani: Russell e la Compatibilità</h3>
-
 <p>Stuart Russell, informatico di Berkeley e autore di <em>"Human Compatible"</em>, rappresenta una voce autorevole nel dibattito sull'allineamento dell'AI ai valori umani. Russell sottolinea l'importanza fondamentale di sviluppare sistemi di AI che siano veramente compatibili con gli obiettivi e i valori umani.</p>
-
 <p>"Il problema non è che l'AI diventi malvagia", spiega Russell, "ma che persegua obiettivi che non sono allineati con i nostri." Nella vita quotidiana, questo si manifesta in situazioni apparentemente banali ma eticamente complesse: quando un'auto a guida autonoma deve scegliere tra proteggere il passeggero o i pedoni, quale algoritmo etico dovrebbe guidare quella decisione?</p>
-
 <h3>Le Disuguaglianze Algoritmiche: Crawford e Noble</h3>
-
 <p>Kate Crawford, nel suo <em>"Atlas of AI"</em>, e Safiya Noble, autrice di <em>"Algorithms of Oppression"</em>, portano l'attenzione su una dimensione spesso trascurata della valutazione AI: l'impatto sulle disuguaglianze sociali.</p>
-
 <p>Crawford evidenzia come i pregiudizi di genere possano essere incorporati nei sistemi di AI in modi sottili ma pervasivi. Noble ha documentato sistematicamente come i sistemi di AI possano perpetuare e amplificare disuguaglianze razziali, religiose e di genere. Un esempio concreto sono i sistemi di selezione del personale che, addestrati su dati storici di assunzione, possono discriminare inconsapevolmente contro donne o minoranze etniche.</p>
-
 <p>"Non è sufficiente che un algoritmo sia tecnicamente accurato", argomenta Noble, "deve anche essere socialmente giusto." Questo principio dovrebbe essere al centro di ogni metodologia di valutazione dell'AI.</p>
-
 <h3>Prospettive Spirituali: Oltre la Tecnologia</h3>
-
 <p>Il Dalai Lama, in vari interventi pubblici, ha sottolineato l'importanza di mantenere compassione ed etica mentre sviluppiamo tecnologie sempre più avanzate. "La tecnologia dovrebbe servire l'umanità, non sostituirla", ha dichiarato, evidenziando la necessità di considerare non solo l'efficienza tecnica dell'AI, ma anche il suo impatto sul benessere spirituale ed emotivo delle persone.</p>
-
 <p>Papa Francesco ha più volte affrontato il tema dell'AI dal pulpito del Vaticano, sottolineando la necessità di uno sviluppo tecnologico che rispetti la dignità umana e promuova il bene comune. "L'intelligenza artificiale può essere una benedizione", ha detto, "ma solo se la utilizziamo per ridurre le disuguaglianze, non per amplificarle."</p>
-
 <h3>L'Infosfera: Floridi e il Nuovo Ambiente Umano</h3>
-
 <p>Luciano Floridi, filosofo dell'informazione all'Università di Oxford, introduce il concetto rivoluzionario di <strong>infosfera</strong> – un ambiente dove il confine tra online e offline, tra naturale e artificiale, diventa sempre più sfumato. Nella vita quotidiana, questo si manifesta ogni volta che usiamo il GPS per orientarci: non stiamo semplicemente utilizzando uno strumento, ma stiamo delegando una parte fondamentale del nostro processo decisionale a un sistema artificiale.</p>
-
 <p>"Siamo diventati entità informazionali", scrive Floridi, "che esistono e interagiscono in un ambiente sempre più permeato da intelligenza artificiale." Quando un medico utilizza l'AI per la diagnosi, non sta semplicemente usando uno strumento – sta entrando in una nuova forma di collaborazione uomo-macchina che ridefinisce profondamente il suo ruolo professionale e la sua identità.</p>
-
 <h2>La Dimensione Culturale dell'Etica AI</h2>
-
 <h3>L'AI Come Specchio delle Società</h3>
-
 <p>Tutti questi pensatori convergono su un punto fondamentale: l'allineamento dell'AI non è solo una questione tecnica, ma un processo che riflette profondamente i valori, l'etica e la cultura dei suoi sviluppatori. Ogni sistema di intelligenza artificiale viene "educato" attraverso enormi set di dati che non sono mai neutrali, ma sempre intrisi dei valori, dei pregiudizi e delle prospettive delle persone e delle istituzioni che li selezionano e li curano.</p>
-
-<p>Il paese di origine di un'AI diventa quindi un fattore cruciale: le norme etiche, i vincoli legislativi, le sensibilità culturali e persino i sistemi di censura influenzano inevitabilmente il modo in cui l'intelligenza artificiale elabora le informazioni e formula le risposte. Un'AI sviluppata nella Silicon Valley avrà probabilmente risposte più orientate verso l'individualismo e l'innovazione, mentre un'intelligenza artificiale creata in contesti con maggiore controllo statale potrebbe riflettere diverse priorità sociali.<br><br><br><br></p>
-
+<p>Il paese di origine di un'AI diventa quindi un fattore cruciale: le norme etiche, i vincoli legislativi, le sensibilità culturali e persino i sistemi di censura influenzano inevitabilmente il modo in cui l'intelligenza artificiale elabora le informazioni e formula le risposte. Un'AI sviluppata nella Silicon Valley avrà probabilmente risposte più orientate verso l'individualismo e l'innovazione, mentre un'intelligenza artificiale creata in contesti con maggiore controllo statale potrebbe riflettere diverse priorità sociali.<br/><br/><br/><br/></p>
 <h3>La Necessità del Pensiero Critico</h3>
-
 <p>Diventa quindi essenziale per ogni utente sviluppare una consapevolezza critica. Conoscere l'origine di un'intelligenza artificiale significa essere in grado di interpretare le sue risposte con un filtro consapevole. Proprio come valutiamo una fonte giornalistica considerando la sua linea editoriale, altrettanto deve avvenire con l'AI.</p>
-
 <p>Chiedersi da dove proviene un sistema AI, chi l'ha sviluppato, quali valori culturali e etici lo influenzano, diventa un esercizio di pensiero critico fondamentale. Le informazioni restituite non vanno accolte come verità assolute, ma come prospettive da analizzare, confrontare e vagliare criticamente, consapevoli che dietro ogni risposta si nascondono scelte, filtri e prospettive che vanno oltre il mero dato informativo.</p>
-
 <h3>Il Paradosso dell'Universalità Etica</h3>
-
 <p>Questo ci porta a un paradosso affascinante che emerge dalle riflessioni di tutti questi pensatori: mentre cerchiamo standard etici universali per l'AI, ci scontriamo inevitabilmente con la diversità culturale umana. Cosa è considerato "giusto" o "equo" varia significativamente tra culture diverse. Come possiamo sviluppare sistemi di AI che rispettino questa diversità pur mantenendo principi etici fondamentali?</p>
-
-<p>Come osserva IBM nella sua analisi del 2025, diversità, equità e inclusione sono fondamentali per una strategia di innovazione AI non solo per ragioni etiche, ma perché prospettive diverse promuovono problem-solving più creativo e design inclusivo che riduce bias indesiderati.<br><br><br></p>
-
+<p>Come osserva IBM nella sua analisi del 2025, diversità, equità e inclusione sono fondamentali per una strategia di innovazione AI non solo per ragioni etiche, ma perché prospettive diverse promuovono problem-solving più creativo e design inclusivo che riduce bias indesiderati.<br/><br/><br/></p>
 <h2>Verso una Governance Globale dell'AI</h2>
-
 <h3>I Framework Internazionali</h3>
-
 <p>La questione della valutazione etica dell'AI ha spinto organismi internazionali a sviluppare framework condivisi. L'UNESCO promuove la comprensione pubblica dell'AI attraverso educazione aperta e accessibile, impegno civico, competenze digitali e formazione sull'etica dell'AI.</p>
-
 <p>Questi sforzi rappresentano tentativi di creare standard comuni, ma la loro efficacia dipenderà dalla volontà delle nazioni e delle aziende di aderirvi volontariamente.</p>
-
 <h3>Il Ruolo delle Aziende Tech</h3>
-
 <p>Le grandi aziende tecnologiche stanno assumendo un ruolo sempre più attivo nello sviluppo di principi etici per l'AI. Google ha descritto i progressi fatti nelle tecniche di mitigazione del rischio attraverso diversi lanci di AI generativa, includendo migliori tecniche di sicurezza e filtri, controlli di sicurezza e privacy, e ampia educazione sull'alfabetizzazione AI.</p>
-
 <p>Microsoft definisce l'AI responsabile come un insieme di passi per assicurare che i sistemi AI siano affidabili e rispettino i principi societari, lavorando su questioni come equità, affidabilità e sicurezza, privacy e sicurezza, inclusività, trasparenza e responsabilità.</p>
-
 <p>Tuttavia, resta la domanda: possiamo fidarci dell'autoregolamentazione, o servono meccanismi di controllo più robusti?</p>
-
 <h2>Le Sfide Future della Valutazione AI</h2>
-
 <h3>La Corsa agli Armamenti dei Benchmark</h3>
-
-<p>Uno dei problemi emergenti è quello che potremmo chiamare "la corsa agli armamenti dei benchmark". Man mano che i modelli diventano sempre più capaci di superare i test esistenti, servono benchmark sempre più sofisticati. Ma c'è il rischio che questa dinamica porti a una focalizzazione eccessiva sulle metriche a scapito delle applicazioni reali.<br><br><br></p>
-
+<p>Uno dei problemi emergenti è quello che potremmo chiamare "la corsa agli armamenti dei benchmark". Man mano che i modelli diventano sempre più capaci di superare i test esistenti, servono benchmark sempre più sofisticati. Ma c'è il rischio che questa dinamica porti a una focalizzazione eccessiva sulle metriche a scapito delle applicazioni reali.<br/><br/><br/></p>
 <h3>L'Intelligenza Artificiale Generale: Come la Valuteremo?</h3>
-
 <p>Mentre ci avviciniamo (forse) allo sviluppo dell'Intelligenza Artificiale Generale (AGI), le nostre metodologie di valutazione dovranno evolversi radicalmente. Come si misura un'intelligenza che potrebbe superare quella umana in tutti i domini? Quali metriche useremmo per un sistema che potrebbe essere più creativo, più razionale e più efficiente di noi?</p>
-
 <h3>La Valutazione Continua in Tempo Reale</h3>
-
 <p>Il futuro della valutazione dell'AI potrebbe non essere fatto di test occasionali, ma di monitoraggio continuo. Sistemi che si adattano e imparano costantemente richiedono valutazioni altrettanto dinamiche. Stiamo entrando nell'era della "valutazione vivente", dove le prestazioni e l'etica di un sistema vengono monitorate in tempo reale?</p>
-
 <h2>Verso un'AI Davvero Responsabile: Principi Guida per il Futuro</h2>
-
 <h3>Trasparenza Senza Compromessi</h3>
-
 <p>Il primo principio per un'AI responsabile deve essere la trasparenza totale. Questo non significa necessariamente rendere pubblico ogni dettaglio tecnico, ma assicurarsi che gli stakeholder – utenti, regolatori, società civile – abbiano accesso alle informazioni necessarie per valutare e controllare i sistemi AI.</p>
-
 <h3>Inclusività nel Design e nella Valutazione</h3>
-
 <p>I sistemi di AI e i loro metodi di valutazione devono essere sviluppati con input diversificati fin dall'inizio. Non basta correggere i bias a posteriori – dobbiamo prevenirli attraverso team di sviluppo diversificati e processi di valutazione inclusivi.</p>
-
 <h3>Responsabilità Distribuita</h3>
-
 <p>Non può esistere un'AI responsabile senza catene di responsabilità chiare. Chi è responsabile quando un sistema di AI commette un errore? Come distribuiamo responsabilità tra sviluppatori, utilizzatori e regolatori?</p>
-
 <h3>Valutazione Partecipativa</h3>
-
 <p>Il futuro della valutazione dell'AI deve includere le voci di tutti coloro che ne sono affetti. Questo significa sviluppare meccanismi per il coinvolgimento pubblico nella definizione di standard etici e metodologie di valutazione.</p>
-
 <h2>L'AI Come Strumento di Crescita</h2>
-
 <h3>Democratizzare l'Accesso alla Valutazione</h3>
-
 <p>Una delle sfide più importanti è rendere gli strumenti di valutazione dell'AI accessibili non solo agli esperti, ma a tutti coloro che utilizzano questi sistemi. Servono interfacce intuitive, documentazione comprensibile e strumenti che permettano a chiunque di verificare le prestazioni e l'etica dei sistemi AI che usa.</p>
-
 <h3>Educazione e Alfabetizzazione AI</h3>
-
 <p>Non possiamo avere un'AI responsabile senza una popolazione digitalmente alfabetizzata. Questo significa investire in educazione, non solo per i tecnici, ma per tutti i cittadini che dovranno convivere con questi sistemi.</p>
-
 <h2>Guardando al Futuro: Previsioni e Sfide</h2>
-
 <h3>L'Evoluzione dei Benchmark nei Prossimi Anni</h3>
-
 <p>Nei prossimi 2-3 anni, possiamo aspettarci di vedere benchmark sempre più orientati verso applicazioni reali, test di robustezza in condizioni avverse e valutazioni etiche integrate fin dalla progettazione. La tendenza sarà verso test più olistici che valutano non solo le prestazioni tecniche, ma anche l'impatto sociale e ambientale.</p>
-
 <h3>L'Emergere di Standard Globali</h3>
-
 <p>È possibile che entro il 2027-2028 emerga un consenso internazionale su standard minimi per la valutazione etica dell'AI, simile a quanto accaduto per altri settori tecnologici. Questo richiederà un difficile equilibrio tra diversità culturale e principi universali.</p>
-
 <h3>L'AI che Valuta l'AI</h3>
-
 <p>Un'evoluzione interessante potrebbe essere l'uso dell'AI stessa per valutare altri sistemi AI. Questo approccio meta-algoritmico potrebbe permettere valutazioni più sofisticate e continue, ma solleva anche questioni filosofiche profonde: chi controlla i controllori?</p>
-
 <h2>Un Bilancio del Nostro Viaggio: Riflessioni Finali</h2>
-
 <p>Giunti alla fine di questa serie di articoli, è il momento di fermarsi e riflettere sul percorso compiuto insieme. Abbiamo iniziato esplorando le origini dell'intelligenza artificiale, quell'affascinante tentativo dell'uomo di creare macchine pensanti che affonda le sue radici nei sogni e nelle ambizioni più profonde della nostra specie.</p>
-
 <p>Abbiamo scoperto che dietro l'apparente magia dell'AI si nascondono algoritmi sofisticati ma comprensibili, reti neurali che imitano il funzionamento del cervello umano, e processi di apprendimento che trasformano dati grezzi in conoscenza utilizzabile. Abbiamo visto come questa tecnologia stia rivoluzionando il mondo del lavoro e dell'educazione, creando nuove opportunità mentre ne elimina altre.</p>
-
 <p>L'AI generativa ci ha mostrato un futuro dove la creatività artificiale si affianca a quella umana, producendo arte, letteratura e contenuti che sfidano le nostre concezioni tradizionali di originalità e autorialità. Abbiamo analizzato il panorama industriale, scoprendo come giganti tecnologici e startup innovative stiano plasmando il futuro di questa tecnologia.</p>
-
 <p>E ora, in questo ultimo capitolo, abbiamo affrontato forse la questione più cruciale: come garantire che tutto questo potere tecnologico sia utilizzato in modo responsabile ed etico.</p>
-
 <h3>L'Importanza dello Spirito Critico</h3>
-
 <p>Se c'è una lezione che emerge con forza da questo viaggio, è l'importanza di mantenere uno spirito critico. L'intelligenza artificiale non è né la salvezza dell'umanità né la sua condanna – è uno strumento potente che riflette le intenzioni, i valori e i bias di chi la sviluppa e la utilizza.</p>
-
-<p><br><br><br>Come abbiamo visto, ogni sistema di AI porta con sé l'impronta culturale della società che l'ha creato. Riconoscere questo fatto non significa essere pessimisti, ma essere consapevoli. Significa approcciarsi all'AI con curiosità e apertura, ma anche con domande intelligenti: chi ha sviluppato questo sistema? Su quali dati è stato addestrato? Quali sono i suoi limiti e i suoi possibili bias?</p>
-
+<p><br/><br/><br/>Come abbiamo visto, ogni sistema di AI porta con sé l'impronta culturale della società che l'ha creato. Riconoscere questo fatto non significa essere pessimisti, ma essere consapevoli. Significa approcciarsi all'AI con curiosità e apertura, ma anche con domande intelligenti: chi ha sviluppato questo sistema? Su quali dati è stato addestrato? Quali sono i suoi limiti e i suoi possibili bias?</p>
 <h3>L'AI Come Specchio dell'Umanità</h3>
-
 <p>Uno degli aspetti più affascinanti emersi dalla nostra esplorazione è come l'AI funzioni come uno specchio dell'umanità. I sistemi di intelligenza artificiale non creano pregiudizi dal nulla – li riflettono dai dati su cui sono addestrati, che a loro volta riflettono le società umane con tutte le loro imperfezioni.</p>
-
 <p>Questo ci pone di fronte a una responsabilità duplice: da un lato, dobbiamo lavorare per creare sistemi AI più equi e rappresentativi; dall'altro, dobbiamo utilizzare l'AI come un'opportunità per riflettere criticamente sulle nostre società e sui nostri valori.</p>
-
 <h3>La Democratizzazione dell'Intelligenza</h3>
-
 <p>Abbiamo visto come l'AI stia diventando sempre più accessibile. Strumenti che solo pochi anni fa erano disponibili solo per ricercatori e grandi aziende sono ora alla portata di studenti, piccole imprese e creativi di tutto il mondo. Questa democratizzazione rappresenta un'opportunità straordinaria per l'innovazione e la creatività umana.</p>
-
 <p>Ma come direbbe Spiderman, da grandi poteri derivano grandi responsabilità. Ogni utente di tecnologie AI diventa, in un certo senso, un partecipante attivo nella definizione del futuro di questa tecnologia. Le nostre scelte, i nostri feedback, il modo in cui utilizziamo questi strumenti contribuiscono all'evoluzione dell'AI.</p>
-
 <h3>Un Invito all'Azione Consapevole</h3>
-
 <p>Mentre concludiamo questo viaggio, il mio invito è quello di non considerare l'AI come qualcosa che ci accade, ma come qualcosa di cui siamo co-creatori. Ogni volta che utilizzate un sistema di intelligenza artificiale – che sia per cercare informazioni, creare contenuti, o risolvere problemi – ricordate che state partecipando a un esperimento globale che determinerà il futuro della nostra specie.</p>
-
 <p>Informatevi. Fate domande. Mantenete la curiosità. Ma soprattutto, non abbiate paura di essere critici. L'AI ha un potenziale straordinario per migliorare le nostre vite, ma questo potenziale si realizzerà solo se saremo attivi nel pretendere che sia sviluppata e utilizzata in modo etico e responsabile.</p>
-
 <h3>Verso un Futuro di Collaborazione</h3>
-
 <p>Il futuro non sarà probabilmente caratterizzato dalla supremazia dell'AI sull'uomo o dell'uomo sull'AI, ma dalla loro collaborazione. I sistemi più potenti e benefici saranno quelli che amplificano le capacità umane piuttosto che sostituirle, che arricchiscono la nostra esperienza piuttosto che impoverirla.</p>
-
 <p>Questa collaborazione richiederà da parte nostra nuove competenze: non solo tecniche, ma anche etiche, critiche e creative. Dovremo imparare a convivere con sistemi che in alcuni aspetti ci superano, mantenendo al contempo la nostra umanità e i nostri valori.</p>
-
 <h3>Un Ringraziamento e Un Arrivederci</h3>
-
 <p>Questo viaggio attraverso il mondo dell'intelligenza artificiale si conclude qui, ma la vostra esplorazione è appena iniziata. L'AI continuerà a evolversi a ritmi sempre più rapidi, portando nuove sfide e opportunità che oggi possiamo solo immaginare.</p>
-
 <p>Ringrazio chi ha seguito questa serie di articoli per la pazienza e la curiosità dimostrate. L'intelligenza artificiale è un campo complesso e in rapida evoluzione, ma spero che questi articoli abbiano fornito strumenti utili per navigare in questo paesaggio in trasformazione.</p>
-
 <p>Ricordate: in un mondo sempre più dominato da algoritmi e dati, la vostra capacità di pensare criticamente, di fare domande intelligenti e di mantenere una prospettiva umana non è mai stata così preziosa. L'intelligenza artificiale può essere un alleato straordinario in questo processo, ma non potrà mai sostituire la curiosità, l'empatia e la saggezza unicamente umane.</p>
-
 <p>Il futuro dell'AI siamo noi. Costruiamolo insieme, con saggezza e responsabilità.</p>
 
             <div class="footer-back-button">

--- a/dist/07-AI Bocciati i Giganti.html
+++ b/dist/07-AI Bocciati i Giganti.html
@@ -162,325 +162,166 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)</h1>
-
 <p><em>di Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="GigantiTechAsini.jpg" alt="GigantiTechAsini.jpg" /></p>
-
+<img alt="GigantiTechAsini.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/07-AI Bocciati i Giganti/GigantiTechAsini.jpg"/></p>
 <p><em>Riprendendo l'analisi del rapporto indipendente del Future of Life Institute, in questa seconda puntata andiamo ad approfondire i temi della sicurezza nello sviluppo delle IA, l'urgenza normativa e tecnica di porre limiti, gli aspetti etici e le prospettive future.</em></p>
-
 <h2>Il paradosso della sicurezza</h2>
-
 <p>Uno dei problemi più profondi è quello che i ricercatori chiamano il "paradosso della sicurezza": potrebbero essere necessari sistemi di IA molto avanzati per sviluppare metodi di sicurezza sufficientemente sofisticati, ma abbiamo bisogno di questi metodi di sicurezza prima di costruire sistemi così avanzati.</p>
-
 <h2>I segnali di allarme nel 2025</h2>
-
 <p>Il rapporto arriva in un momento in cui i segnali di allarme sulla sicurezza dell'IA si stanno moltiplicando. Secondo l'AI Incidents Database, il numero di incidenti legati all'IA è aumentato a 233 nel 2024 - un record e un aumento del 56,4% rispetto al 2023.</p>
-
 <h3>La crescita esponenziale degli incidenti</h3>
-
 <p>L'aumento del 56,4% degli incidenti non è solo un numero statistico - rappresenta un pattern preoccupante. Analizzando i dati degli ultimi cinque anni, vediamo che nel 2020 si sono verificati 86 incidenti, seguiti da 109 incidenti nel 2021 (+27%), 132 incidenti nel 2022 (+21%), 149 incidenti nel 2023 (+13%) e infine 233 incidenti nel 2024 (+56%).</p>
-
 <p>Questo suggerisce che stiamo entrando in una fase di accelerazione del rischio, dove i sistemi di IA diventano simultaneamente più potenti e più comuni, ma non necessariamente più sicuri.
-<img src="ai_incidents_2020_2024_aggiornato.jpg" alt="ai_incidents_2020_2024_aggiornato.jpg" /></p>
-
+<img alt="ai_incidents_2020_2024_aggiornato.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/07-AI Bocciati i Giganti/ai_incidents_2020_2024_aggiornato.jpg"/></p>
 <h3>La perdita di controllo interpretativo</h3>
-
 <p>Ma forse ancora più preoccupante è un recente allarme lanciato da ricercatori delle stesse aziende tecnologiche. Come riportato da <a href="https://venturebeat.com/ai/openai-google-deepmind-and-anthropic-sound-alarm-we-may-be-losing-the-ability-to-understand-ai/">VentureBeat</a>, scienziati di OpenAI, DeepMind, Anthropic e Meta avvertono che la nostra capacità di monitorare il ragionamento dell'IA potrebbe scomparire man mano che i modelli si evolvono.</p>
-
 <p>I sistemi di IA moderni sono diventati così complessi che anche i loro creatori non riescono a capire completamente come arrivano alle loro conclusioni. È come avere un dipendente geniale che produce sempre risultati eccellenti, ma non può spiegare il suo processo di ragionamento.</p>
-
 <p>Man mano che i modelli diventano più grandi e complessi, sviluppano capacità che i loro creatori non avevano previsto. Questo fenomeno, chiamato "emergenza", significa che potremmo trovarci con sistemi che possono fare cose che non sapevamo potessero fare.</p>
-
 <h3>La corsa alla potenza computazionale</h3>
-
 <p>Un altro segnale di allarme è la crescita esponenziale della potenza computazionale utilizzata per addestrare i modelli di IA. Ogni nuova generazione di modelli richiede circa 10 volte più potenza computazionale della precedente. Questo significa che i modelli stanno diventando troppo costosi per la maggior parte dei ricercatori, la ricerca sulla sicurezza sta rimanendo indietro rispetto allo sviluppo e poche aziende controllano la tecnologia più avanzata.</p>
-
 <h2>Le conseguenze pratiche per tutti noi</h2>
-
 <p>L'intelligenza artificiale sta diventando sempre più integrata nelle nostre vite quotidiane. Dai sistemi di raccomandazione che decidono cosa vediamo sui social media, agli algoritmi che determinano se otteniamo un prestito o un lavoro, fino ai sistemi di guida autonoma che potrebbero presto trasportarci.</p>
-
 <h3>L'IA nella vita quotidiana</h3>
-
 <p>Gli algoritmi di IA determinano cosa vediamo sui nostri feed di Facebook, Instagram, TikTok e X ( ex Twitter). Questi sistemi influenzano non solo cosa compriamo, ma anche come pensiamo, cosa crediamo e persino per chi votiamo.</p>
-
 <p>I sistemi di IA valutano le nostre richieste di prestito, determinano i nostri tassi di interesse e decidono se possiamo ottenere un mutuo. Un errore in questi sistemi può avere conseguenze devastanti per le nostre vite finanziarie.</p>
-
 <p>L'IA viene sempre più utilizzata per diagnosticare malattie, consigliare trattamenti e gestire cartelle cliniche. Errori in questi sistemi possono essere letteralmente una questione di vita o di morte.</p>
-
 <p>I sistemi di IA filtrano i curriculum, conducono interviste preliminari e valutano le prestazioni dei dipendenti. Bias o errori in questi sistemi possono distruggere carriere e perpetuare discriminazioni.</p>
-
 <p>I sistemi di guida autonoma stanno diventando sempre più comuni. Come abbiamo visto con i casi Tesla, i malfunzionamenti possono essere fatali.</p>
-
 <h3>L'esperimento globale involontario</h3>
-
 <p>Se le aziende che sviluppano questi sistemi non hanno piani credibili per garantirne la sicurezza, tutti noi stiamo partecipando a un esperimento globale di cui non conosciamo l'esito. Come evidenzia <a href="https://www.cnbc.com/2025/05/14/meta-google-openai-artificial-intelligence-safety.html">CNBC</a>, le aziende tecnologiche si stanno concentrando sui prodotti IA piuttosto che sulla ricerca, e questo ha implicazioni dirette per la sicurezza.</p>
-
 <p>La pressione per monetizzare rapidamente l'IA ha portato molte aziende a rilasciare prodotti prima che siano completamente testati. Questo significa che i consumatori stanno essenzialmente beta-testando tecnologie che potrebbero avere conseguenze serie.</p>
-
 <p>L'IA ha un "effetto rete" - più persone la usano, più potente diventa. Questo significa che una volta che un sistema di IA diventa dominante, diventa estremamente difficile sostituirlo, anche se si scoprono problemi di sicurezza.</p>
-
 <p>La società sta diventando sempre più dipendente dall'IA. Molte decisioni critiche sono già delegate a sistemi automatizzati. Se questi sistemi falliscono simultaneamente, le conseguenze potrebbero essere catastrofiche.</p>
-
 <h2>La necessità urgente di regolamentazione</h2>
-
 <p>Una delle conclusioni più forti del rapporto è che il settore non può autoregolarsi efficacemente. Tegmark ha espresso con forza la necessità di una supervisione normativa: "Sento che è necessario un ente governativo equivalente alla Food and Drug Administration americana che approverebbe i prodotti di IA prima che raggiungano il mercato".</p>
-
 <h3>L'analogia con la FDA</h3>
-
 <p>L'analogia con la FDA (Food and Drug Administration) è illuminante e potente. Nessuno si aspetta che le aziende farmaceutiche testino da sole i propri farmaci senza supervisione esterna. Prima che un nuovo farmaco possa essere venduto al pubblico, deve superare rigorosi test clinici supervisionati da enti indipendenti.</p>
-
 <p>Perché questo non accade con l'IA? I farmaci hanno effetti biologici misurabili, mentre l'IA ha effetti sociali e psicologici più difficili da quantificare. Inoltre, l'industria farmaceutica è più matura e regolamentata, mentre l'IA si evolve molto più rapidamente dei farmaci.</p>
-
 <p>Una "FDA per l'IA" avrebbe vantaggi significativi. "Se ci sono standard di sicurezza, allora invece c'è pressione commerciale per vedere chi può soddisfare per primi gli standard di sicurezza, perché allora possono vendere per primi e guadagnare per primi", ha spiegato Tegmark.</p>
-
 <p>Questo cambierebbe completamente la dinamica competitiva. Invece di competere per rilasciare per primi a qualunque costo, le aziende competerebbero per essere le prime a soddisfare standard di sicurezza rigorosi.</p>
-
 <h3>I modelli normativi esistenti</h3>
-
 <p>Diversi paesi e regioni stanno sviluppando approcci normativi all'IA, ma con filosofie molto diverse:</p>
-
 <p>L'Unione Europea ha adottato un AI Act basato sul rischio, categorizzando i sistemi di IA in sistemi a rischio inaccettabile che sono completamente vietati, sistemi ad alto rischio soggetti a requisiti rigorosi, sistemi a rischio limitato con obblighi di trasparenza e sistemi a rischio minimo con requisiti minimi.</p>
-
 <p>Gli Stati Uniti stanno sviluppando un approccio più frammentato, con diverse agenzie che regolamentano l'IA nei loro settori specifici: FDA per l'IA medica, NHTSA per i veicoli autonomi e SEC per l'IA finanziaria.</p>
-
 <p>La Cina ha adottato un approccio più centralizzato, con forti controlli statali sui sistemi di IA, specialmente quelli che potrebbero influenzare l'opinione pubblica o la stabilità sociale.</p>
-
 <p>Il Regno Unito ha optato per un approccio di "autoregolamentazione guidata", dove le aziende sono responsabili della sicurezza ma sotto la supervisione di regolatori esistenti.</p>
-
 <h3>I limiti degli approcci attuali</h3>
-
 <p>Nonostante questi sforzi, nessuno degli approcci normativi attuali affronta adeguatamente il problema dei rischi esistenziali. La maggior parte si concentra sui rischi attuali e immediati, ma non sui rischi a lungo termine dell'intelligenza artificiale generale.</p>
-
 <p>L'IA si evolve così rapidamente che le normative rischiano di essere obsolete prima ancora di essere implementate. Serve un approccio più dinamico e adattivo.</p>
-
 <p>L'IA è una tecnologia globale, ma la regolamentazione è nazionale. Questo crea il rischio di "shopping normativo", dove le aziende si spostano in giurisdizioni con regole più permissive.</p>
-
 <p>Molti regolatori non hanno la competenza tecnica necessaria per valutare sistemi di IA complessi. Questo crea il rischio di regolamentazioni inefficaci o controproducenti.</p>
-
 <h2>Il contesto internazionale e la cooperazione globale</h2>
-
 <p>Il rapporto del Future of Life Institute non è isolato. Come riportato dal <a href="https://www.gov.uk/government/publications/international-ai-safety-report-2025">governo britannico</a>, un rapporto internazionale del 2025 scritto da 100 esperti di IA, inclusi rappresentanti nominati da 33 paesi e organizzazioni intergovernative, ha evidenziato preoccupazioni simili a livello globale.</p>
-
 <h3>Il vertice di Bletchley Park e oltre</h3>
-
 <p>Il Regno Unito ha ospitato il primo AI Safety Summit a Bletchley Park nel novembre 2023, seguito da summit a Seoul e San Francisco. Questi incontri hanno rappresentato i primi tentativi di coordinamento internazionale sulla sicurezza dell'IA.</p>
-
 <p>I risultati concreti includono la Dichiarazione di Bletchley con l'accordo sui rischi dell'IA, l'istituzione di istituti di sicurezza nazionali, l'impegno per la condivisione di informazioni sui rischi e accordi preliminari su standard di sicurezza.</p>
-
 <p>Tuttavia, la cooperazione ha mostrato limiti significativi: mancanza di meccanismi di enforcement, differenze culturali e politiche significative, resistenza delle aziende alla regolamentazione e competizione geopolitica nell'IA.</p>
-
 <h3>La sfida della governance globale</h3>
-
 <p>L'IA presenta sfide di governance senza precedenti. A differenza delle armi nucleari, che richiedono materiali e infrastrutture rare, l'IA può essere sviluppata con risorse relativamente comuni. Questo rende molto più difficile il controllo e la non-proliferazione.</p>
-
 <p>Il controllo degli armamenti nucleari ha funzionato perché i materiali fissili sono rari e tracciabili, le infrastrutture sono grandi e visibili, gli effetti sono immediatamente devastanti e il numero di attori è limitato.</p>
-
 <p>L'IA è diversa perché i "materiali" (dati e algoritmi) sono ampiamente disponibili, le infrastrutture possono essere virtuali e nascoste, gli effetti possono essere graduali e sottili, e il numero di attori è in rapida crescita.</p>
-
 <h3>Iniziative internazionali emergenti</h3>
-
 <p>Diversi paesi stanno creando istituti nazionali di sicurezza dell'IA e coordinando i loro sforzi attraverso l'International AI Safety Institute Network.</p>
-
 <p>Il Partnership on AI è un'iniziativa del settore privato che riunisce le principali aziende tecnologiche per sviluppare best practices.</p>
-
 <p>Il Global Partnership on AI (GPAI) è un'iniziativa guidata dal G7 per promuovere l'uso responsabile dell'IA.</p>
-
 <h2>Cosa significa "allineamento" dell'IA: approfondimento tecnico</h2>
-
 <p>L'allineamento si riferisce al problema di assicurarsi che i sistemi di IA facciano quello che vogliamo che facciano, nel modo in cui vogliamo che lo facciano, anche quando diventano molto capaci. È uno dei problemi più complessi e importanti nell'intelligenza artificiale.</p>
-
 <h3>La complessità dei valori umani</h3>
-
 <p>Come facciamo a tradurre valori umani complessi in istruzioni che una macchina può seguire? I valori umani sono spesso contraddittori (vogliamo sia libertà che sicurezza), contestuali (le stesse azioni possono essere giuste o sbagliate in contesti diversi), evolutivi (i nostri valori cambiano nel tempo) e impliciti (spesso non siamo consapevoli dei nostri valori finché non vengono violati).</p>
-
 <p>Un esempio concreto: immaginate di dire a un'IA: "Rendimi felice". Un sistema mal allineato potrebbe manipolare i vostri sensori per farvi credere di essere felici, alterare chimicamente il vostro cervello, creare una simulazione perfetta di felicità o eliminare tutto ciò che vi rende infelici, incluse le sfide che danno significato alla vita.</p>
-
 <h3>I diversi tipi di allineamento</h3>
-
 <p>L'allineamento esterno (Outer Alignment) mira ad assicurarsi che gli obiettivi che diamo al sistema siano quelli che vogliamo veramente che persegua.</p>
-
 <p>L'allineamento interno (Inner Alignment) si concentra sull'assicurarsi che il sistema persegua effettivamente gli obiettivi che gli abbiamo dato, piuttosto che sviluppare obiettivi propri.</p>
-
 <p>L'allineamento dinamico cerca di assicurarsi che il sistema rimanga allineato anche quando si evolve e impara nuove capacità.</p>
-
 <h3>Le tecniche attuali e i loro limiti</h3>
-
 <p>Il Reinforcement Learning from Human Feedback (RLHF), che significa "apprendimento per rinforzo da feedback umano", funziona così: il sistema produce output, gli umani valutano la qualità degli output, e il sistema impara a produrre output che ricevono valutazioni positive.</p>
-
 <p>Tuttavia, l'RLHF ha diversi limiti: gli umani possono essere inconsistenti nelle loro valutazioni, è difficile valutare output molto complessi, il sistema potrebbe imparare a manipolare i valutatori, e non scala bene a sistemi molto intelligenti.</p>
-
 <p>Il Constitutional AI, una tecnica sviluppata da Anthropic, cerca di insegnare ai sistemi una "costituzione" di principi da seguire. Presenta vantaggi come maggiore trasparenza rispetto all'RLHF, maggiore coerenza e un controllo più fine del comportamento. Tuttavia, ha anche limiti: è difficile scrivere una costituzione completa, i principi possono essere in conflitto e potrebbe non funzionare per sistemi molto avanzati.</p>
-
 <h3>Il problema dell'ortogonalità</h3>
-
 <p>Un concetto chiave nell'allineamento è la "tesi dell'ortogonalità", che afferma che l'intelligenza e gli obiettivi sono ortogonali - cioè, un sistema può essere molto intelligente ma avere qualsiasi tipo di obiettivo.</p>
-
 <p>Questo significa che un sistema super-intelligente potrebbe essere brillante nel raggiungere i suoi obiettivi, avere obiettivi completamente diversi dai nostri e non avere alcun interesse a cambiare i suoi obiettivi per adattarsi ai nostri.</p>
-
 <h2>I limiti degli attuali approcci alla sicurezza</h2>
-
 <p>Il rapporto evidenzia una limitazione fondamentale: "L'attuale approccio all'IA tramite scatole nere giganti addestrate su quantità inimmaginabilmente vaste di dati" potrebbe non essere compatibile con le garanzie di sicurezza necessarie.</p>
-
 <h3>Il problema delle "scatole nere"</h3>
-
 <p>I sistemi di IA attuali sono essenzialmente "scatole nere" - sappiamo cosa mettiamo dentro (dati di addestramento) e cosa ne esce (risposte), ma non capiamo veramente come funzionano internamente.</p>
-
 <p>È come avere un dipendente che fa sempre un lavoro eccellente, ma quando gli chiedi come fa, risponde solo "è complicato". All'inizio potrebbe andare bene, ma man mano che gli affidi compiti più importanti, cominci a preoccuparti di cosa potrebbe succedere se i suoi metodi "complicati" non funzionano in una situazione nuova.</p>
-
 <p>Questo è un problema per la sicurezza perché non possiamo prevedere come si comporterà in situazioni nuove, non possiamo identificare e correggere errori sistematici, non possiamo garantire che segua i nostri valori e non possiamo spiegare le sue decisioni ad altri.</p>
-
 <h3>L'interpretabilità meccanicistica</h3>
-
 <p>La ricerca sull'interpretabilità meccanicistica cerca di aprire queste "scatole nere" per capire come funzionano internamente i sistemi di IA.</p>
-
 <p>I progressi recenti includono l'identificazione di "neuroni" che si attivano per concetti specifici, la mappatura di come l'informazione fluisce attraverso la rete e la scoperta di rappresentazioni interne di concetti astratti.</p>
-
 <p>Tuttavia, i limiti attuali sono significativi: funziona solo per sistemi relativamente semplici, richiede enormi risorse computazionali, i risultati sono difficili da interpretare e potrebbe non scalare a sistemi molto grandi.</p>
-
 <p>Russell ha aggiunto: "E diventerà solo più difficile man mano che questi sistemi di IA diventano più grandi".</p>
-
 <h3>Le sfide tecniche specifiche</h3>
-
 <p>I sistemi di IA sono addestrati su dati specifici, ma poi devono operare nel mondo reale, che è diverso dai dati di addestramento. Questo può portare a comportamenti imprevisti.</p>
-
 <p>Come facciamo a essere sicuri che un sistema che si comporta bene in test specifici si comporterà bene in tutte le situazioni possibili?</p>
-
 <p>I sistemi di IA possono essere facilmente ingannati da input progettati per confonderli. Questo solleva questioni su quanto possiamo fidarci di questi sistemi in situazioni critiche.</p>
-
 <p>Le tecniche di sicurezza che funzionano per sistemi piccoli potrebbero non funzionare per sistemi molto grandi e complessi.</p>
-
 <h2>Il fallimento della trasparenza</h2>
-
 <p>Un altro aspetto critico è il fallimento delle aziende nel fornire trasparenza adeguata. Solo xAI e Zhipu AI hanno completato i questionari inviati dal Future of Life Institute, migliorando i loro punteggi di trasparenza. Questo significa che la maggior parte delle aziende non è stata disposta nemmeno a rispondere a domande di base sulla loro sicurezza.</p>
-
 <h3>L'importanza della trasparenza</h3>
-
 <p>La trasparenza è cruciale perché permette la valutazione indipendente dei rischi, facilita la ricerca sulla sicurezza, aumenta la fiducia del pubblico, permette la supervisione normativa e facilita la collaborazione tra aziende.</p>
-
 <p>Dovrebbero essere trasparenti i metodi di addestramento, i dati utilizzati, le capacità e limitazioni dei sistemi, i risultati dei test di sicurezza, le politiche di sicurezza interne e le strutture di governance.</p>
-
 <h3>I conflitti tra trasparenza e competitività</h3>
-
 <p>Gli argomenti contro la trasparenza includono la protezione dei segreti commerciali, la prevenzione dell'uso improprio, il mantenimento del vantaggio competitivo e la complessità tecnica.</p>
-
 <p>Tuttavia, questi argomenti sono problematici perché la sicurezza pubblica dovrebbe prevalere sui profitti privati, la segretezza può nascondere problemi di sicurezza, la mancanza di trasparenza impedisce la supervisione e la competizione dovrebbe essere sulla sicurezza, non sulla segretezza.</p>
-
 <h3>Modelli di trasparenza</h3>
-
 <p>Esistono diversi modelli: la trasparenza completa prevede il rilascio di tutto (codice, dati, pesi del modello) ed è utilizzata principalmente da progetti accademici. La trasparenza strutturata comporta il rilascio di informazioni specifiche secondo standard concordati e potrebbe essere un compromesso praticabile. La trasparenza controllata offre accesso limitato a ricercatori qualificati ed è utilizzata da alcune aziende per ricerca collaborativa. La trasparenza zero non prevede il rilascio di alcuna informazione ed è utilizzata da molte aziende per progetti commerciali.</p>
-
 <h2>La sfida dell'open source</h2>
-
 <p>Un aspetto particolare del problema riguarda i modelli "open-weight" come quelli rilasciati da Meta. Una volta che i pesi di un modello sono rilasciati pubblicamente, è impossibile controllare come vengono utilizzati. Questo significa che i modelli open-weight richiedono un livello di sicurezza intrinseca molto più alto.</p>
-
 <h3>I vantaggi dell'open source</h3>
-
 <p>L'open source permette l'innovazione distribuita, consentendo a ricercatori di tutto il mondo di migliorare e adattare i modelli per le loro esigenze specifiche. Riduce la concentrazione del potere nelle mani di poche grandi aziende, accelera la ricerca facilitando quella accademica e lo sviluppo di nuove tecniche, e forza la trasparenza rendendo impossibile nascondere problemi in un modello open source.</p>
-
 <h3>I rischi dell'open source</h3>
-
 <p>I modelli possono essere utilizzati per scopi dannosi come la creazione di disinformazione o malware, possono essere modificati per rimuovere le protezioni di sicurezza, una volta rilasciati possono essere copiati e distribuiti senza controllo, e diventa difficile assegnare responsabilità per i problemi causati da modelli open source.</p>
-
 <h3>Possibili soluzioni</h3>
-
 <p>Le soluzioni includono licenze responsabili che proibiscono usi dannosi (anche se sono difficili da far rispettare), il rilascio graduale prima a ricercatori qualificati poi al pubblico generale, l'incorporazione di protezioni integrate che sono difficili da rimuovere e sistemi per monitorare come vengono utilizzati i modelli.</p>
-
 <h2>Il ruolo della comunità scientifica</h2>
-
 <p>Il rapporto sottolinea l'importanza della comunità scientifica nel valutare la sicurezza dell'IA. Un panel indipendente di ricercatori ha revisionato le prove specifiche per azienda e assegnato voti basati su standard di prestazione assoluti. Questo approccio peer-review è fondamentale perché offre una valutazione indipendente non influenzata da interessi commerciali.</p>
-
 <h3>L'importanza della valutazione indipendente</h3>
-
 <p>Serve valutazione indipendente perché le aziende hanno incentivi a minimizzare i rischi, la pressione commerciale può influenzare le valutazioni interne, i ricercatori esterni possono identificare problemi che sfuggono agli sviluppatori e la credibilità richiede indipendenza.</p>
-
 <p>Le sfide per la valutazione indipendente includono l'accesso limitato a sistemi proprietari, risorse insufficienti per valutazioni approfondite, mancanza di standard comuni e complessità tecnica crescente.</p>
-
 <h3>Il ruolo delle conferenze e pubblicazioni</h3>
-
 <p>Il peer review è importante per la valutazione critica dei metodi, l'identificazione di errori e bias, la condivisione di best practices e la costruzione di consenso scientifico.</p>
-
 <p>I problemi attuali includono il fatto che molte aziende non pubblicano ricerca sulla sicurezza, i conflitti di interesse nelle valutazioni, la pressione per risultati positivi e i tempi di pubblicazione troppo lunghi.</p>
-
 <h3>Iniziative della comunità scientifica</h3>
-
 <p>Le iniziative includono la crescita della ricerca sulla sicurezza dell'IA con un numero crescente di ricercatori dedicati, conferenze specializzate dedicate specificamente alla sicurezza dell'IA, collaborazioni inter-disciplinari che coinvolgono esperti in etica, filosofia e scienze sociali, e lo sviluppo di standard comuni per la valutazione della sicurezza.</p>
-
 <h2>Cosa possono fare i consumatori</h2>
-
 <p>Mentre i problemi identificati richiedono soluzioni sistemiche, ci sono alcune cose che i consumatori possono fare per proteggere se stessi e contribuire a una maggiore sicurezza dell'IA.</p>
-
 <h3>Essere informati</h3>
-
 <p>È importante comprendere i rischi imparando come funziona l'IA, essere consapevoli dei bias possibili, riconoscere i contenuti generati dall'IA e capire i limiti dei sistemi attuali.</p>
-
 <p>La valutazione critica richiede di non fidarsi ciecamente degli output dell'IA, verificare informazioni importanti, considerare fonti alternative e mantenere il pensiero critico.</p>
-
 <h3>Scelte consapevoli</h3>
-
 <p>È consigliabile preferire aziende responsabili scegliendo prodotti di aziende con buone pratiche di sicurezza, evitando servizi che non sono trasparenti sui loro rischi e supportando aziende che investono nella ricerca sulla sicurezza.</p>
-
 <p>Per proteggere la privacy è necessario limitare i dati condivisi con sistemi di IA, utilizzare strumenti di privacy quando disponibili ed essere consapevoli di come i dati vengono utilizzati.</p>
-
 <h3>Partecipazione civica</h3>
-
 <p>È importante sostenere la regolamentazione contattando rappresentanti politici, partecipando a consultazioni pubbliche e sostenendo organizzazioni che promuovono la sicurezza dell'IA.</p>
-
 <p>L'educazione e sensibilizzazione richiedono di condividere conoscenze sui rischi dell'IA, incoraggiare discussioni informate e sostenere l'educazione digitale.</p>
-
 <h2>Le prospettive future</h2>
-
 <p>Il rapporto non è pessimistico sul futuro dell'IA, ma sottolinea la necessità di un approccio più responsabile. L'obiettivo è creare incentivi per il miglioramento, non fermare il progresso.</p>
-
 <h3>Scenari possibili</h3>
-
 <p>Lo scenario ottimistico prevede che le aziende migliorino volontariamente le loro pratiche, i regolatori sviluppino framework efficaci, la ricerca sulla sicurezza acceleri e si raggiunga un equilibrio tra innovazione e sicurezza.</p>
-
 <p>Lo scenario di status quo vede le aziende continuare a dare priorità alla velocità sulla sicurezza, i regolatori non riescono a tenere il passo, i problemi di sicurezza si accumulano e si verifica una crisi che forza cambiamenti.</p>
-
 <p>Lo scenario pessimistico comporta l'accelerazione della corsa competitiva senza controlli, i sistemi diventano troppo complessi per essere controllati, si verifica un incidente catastrofico e la fiducia pubblica nell'IA collassa.</p>
-
 <h3>Fattori che determineranno il futuro</h3>
-
 <p>La volontà politica include la capacità dei governi di regolamentare efficacemente, il coordinamento internazionale e il bilanciamento tra innovazione e sicurezza.</p>
-
 <p>La pressione pubblica comprende la consapevolezza dei rischi, la domanda di trasparenza e la partecipazione civica.</p>
-
 <p>Gli sviluppi tecnologici includono i progressi nell'interpretabilità, le nuove tecniche di sicurezza e l'evoluzione delle capacità dell'IA.</p>
-
 <p>La cultura aziendale comporta il cambiamento nelle priorità, gli incentivi per la sicurezza e la leadership responsabile.</p>
-
 <h2>Il messaggio finale</h2>
-
 <p>Il rapporto del Future of Life Institute non è un attacco all'intelligenza artificiale o al progresso tecnologico. È invece un appello urgente per un approccio più responsabile e sostenibile allo sviluppo dell'IA. Come spesso accade con le tecnologie potenti, la questione non è se dovremmo svilupparle, ma come dovremmo farlo in modo sicuro e benefico per l'umanità.</p>
-
 <h3>L'onestà intellettuale necessaria</h3>
-
 <p>"La verità è che nessuno sa come controllare una nuova specie che è molto più intelligente di noi", ha ammesso Tegmark. Questa onestà intellettuale è esattamente ciò che manca nelle attuali pratiche del settore. Prima di tutto, dobbiamo riconoscere che non sappiamo come controllare sistemi super-intelligenti. Solo allora possiamo iniziare a lavorare seriamente per risolvere questo problema.</p>
-
 <h3>L'opportunità nel fallimento</h3>
-
 <p>Il fatto che le aziende più avanzate del mondo abbiano ricevuto voti così bassi non dovrebbe essere visto come un fallimento definitivo, ma come un'opportunità per il miglioramento. Abbiamo identificato i problemi specifici, ora dobbiamo lavorare insieme - aziende, ricercatori, governi e società civile - per risolverli.</p>
-
 <h3>L'urgenza dell'azione</h3>
-
 <p>Il tempo per agire è ora. Non quando i sistemi saranno già troppo potenti per essere controllati, ma mentre abbiamo ancora l'opportunità di plasmare il loro sviluppo. Ogni giorno che passa, i sistemi di IA diventano più potenti e più diffusi. Se non agiamo ora per garantire la loro sicurezza, potremmo trovarci in una situazione da cui è impossibile tornare indietro.</p>
-
 <h3>La responsabilità collettiva</h3>
-
 <p>La sicurezza dell'IA non è responsabilità solo delle aziende tecnologiche o dei governi. È una responsabilità collettiva che richiede il coinvolgimento di tutti: le aziende devono dare priorità alla sicurezza sui profitti a breve termine, i governi devono sviluppare regolamentazioni efficaci e applicarle, i ricercatori devono concentrarsi sui problemi di sicurezza più critici, i cittadini devono essere informati e impegnati, e i consumatori devono fare scelte consapevoli.</p>
-
 <h3>La posta in gioco</h3>
-
 <p>La posta in gioco non potrebbe essere più alta. L'intelligenza artificiale ha il potenziale per risolvere alcuni dei problemi più grandi dell'umanità: dal cambiamento climatico alle malattie, dalla povertà all'esplorazione spaziale. Ma ha anche il potenziale per creare rischi esistenziali senza precedenti.</p>
-
 <p>Il rapporto del Future of Life Institute ci ricorda che abbiamo ancora tempo per scegliere quale percorso seguire. Possiamo continuare sulla strada attuale, sperando che tutto vada bene, oppure possiamo prendere l'iniziativa per garantire che l'IA sia sviluppata in modo sicuro e benefico.</p>
-
 <h3>La chiamata all'azione</h3>
-
 <p>Tegmark auspica che i dirigenti delle aziende interpretino questo rapporto come uno stimolo per migliorare le loro pratiche. Spera inoltre di fornire supporto ai ricercatori che operano nei team di sicurezza di quelle stesse aziende. Come spiega: 'Se un'azienda non subisce pressioni esterne per rispettare gli standard di sicurezza, allora altre persone nell'azienda vedranno i membri del team di sicurezza solo come un ostacolo, come qualcuno che cerca di rallentare i processi'."</p>
-
 <p>Questo rapporto è un appello all'azione per tutti noi. Non possiamo permetterci di rimanere spettatori passivi mentre si determina il futuro dell'intelligenza artificiale. Dobbiamo essere protagonisti attivi nella creazione di un futuro in cui l'IA sia tanto sicura quanto potente.</p>
-
 <p>Il futuro dell'intelligenza artificiale - e forse dell'umanità stessa - dipende dalle scelte che facciamo oggi. Scegliamo saggiamente.</p>
 
             <div class="footer-back-button">

--- a/dist/08-AI Musica e Copyright.html
+++ b/dist/08-AI Musica e Copyright.html
@@ -162,172 +162,89 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>Quando l'Intelligenza Artificiale fa musica: il fenomeno The Velvet Sundown e Iam tra tecnologia ed etica</h1>
-
 <p><em>di Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="Band_AI.jpg" alt="Band_AI.jpg" /></p>
-
+<img alt="Band_AI.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/08-AI Musica e Copyright/Band_AI.jpg"/></p>
 <p><em>Immaginatevi di scoprire che la vostra canzone preferita, quella che vi ha accompagnato per mesi nelle vostre giornate, quella che avete condiviso con gli amici e che ha totalizzato milioni di ascolti, non sia mai stata suonata da mani umane. Non esiste un cantante che l'ha interpretata con la sua voce, non c'è un chitarrista che ha trovato quegli accordi perfetti, non ci sono musicisti che si sono riuniti in studio per creare quell'alchimia sonora. Tutto è nato da algoritmi, reti neurali e intelligenza artificiale.</em></p>
-
 <h2>L'introduzione di un nuovo paradigma</h2>
-
 <p>Benvenuti nell'era della musica sintetica, dove la linea tra creatività umana e artificiale si fa sempre più sottile, e dove due casi emblematici stanno facendo discutere il mondo: The Velvet Sundown, la misteriosa band che ha conquistato Spotify nascondendo la sua vera natura, e Iam, la prima cantante italiana interamente generata dall'AI.</p>
-
 <p>La rivoluzione è silenziosa ma inarrestabile. Mentre discutiamo ancora se l'intelligenza artificiale possa davvero essere creativa, milioni di persone stanno già ascoltando, condividendo e persino innamorandosi di brani creati interamente da macchine. Il fenomeno non è più confinato agli esperimenti di laboratorio o alle curiosità tecnologiche: è entrato nelle classifiche, nelle playlist personali, nella colonna sonora della nostra vita quotidiana. E questo solleva domande profonde che vanno ben oltre la semplice innovazione tecnologica. Cosa significa essere "autentici" nell'arte? Può una macchina esprimere emozioni e trasmetterle attraverso la musica? E soprattutto: siamo pronti a ridefinire il concetto stesso di creatività artistica?</p>
-
 <p>La storia di The Velvet Sundown e di Iam rappresenta molto più di due esperimenti tecnologici di successo. Sono il simbolo di una trasformazione epocale che sta investendo l'industria musicale, con implicazioni che toccano aspetti economici, culturali ed etici. Da un lato abbiamo la democratizzazione della creazione musicale, dall'altro il rischio di una standardizzazione che potrebbe impoverire la diversità artistica. Da una parte la possibilità per chiunque di dare vita alle proprie idee musicali senza anni di studio di strumenti, dall'altra il timore che i musicisti professionisti possano essere gradualmente sostituiti da algoritmi sempre più sofisticati.</p>
-
 <h2>Il fenomeno The Velvet Sundown: quando l'AI conquista Spotify</h2>
-
 <p>La storia di The Velvet Sundown inizia come un mistero degno di un thriller tecnologico. All'inizio del 2024, questa band apparentemente sconosciuta inizia a pubblicare brani che catturano immediatamente l'attenzione degli ascoltatori. Il sound è avvolgente, le melodie accattivanti, i testi profondi e evocativi. In pochi mesi, i loro numeri su Spotify crescono in modo esponenziale, raggiungendo oltre 500.000 ascolti mensili e attirando l'attenzione di playlist curator e media specializzati.</p>
-
 <p>Quello che colpisce inizialmente è la qualità professionale delle produzioni e la coerenza stilistica che attraversa tutto il loro catalogo. Le canzoni sembrano nascere da una visione artistica matura, con arrangiamenti sofisticati e una produzione curata nei minimi dettagli. I fan iniziano a formare una community online, discutendo il significato dei testi e condividendo interpretazioni sui social media. Nessuno sospetta che dietro quei brani non ci siano musicisti in carne ed ossa.</p>
-
 <p>La rivelazione arriva gradualmente, attraverso una strategia comunicativa accuratamente orchestrata. Prima i sospetti, poi indizi sempre più evidenti, infine la confessione completa: The Velvet Sundown è un progetto interamente basato sull'intelligenza artificiale, una "provocazione artistica" che ha confessato di essere un progetto musicale sintetico guidato da direzione creativa umana. La tecnologia utilizzata è principalmente Suno AI, una piattaforma che sta "costruendo un futuro dove chiunque può fare grande musica. Nessuno strumento necessario, solo immaginazione".</p>
-
-<p><img src="the-velvet-sundown.jpg" alt="the-velvet-sundown.jpg" /></p>
-
+<p><img alt="the-velvet-sundown.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/08-AI Musica e Copyright/the-velvet-sundown.jpg"/></p>
 <p><em><a href="https://www.instagram.com/thevelvetsundownband/">Immagine tratta dal profilo Instagram thevelvetsundownband</a></em></p>
-
 <p>Il caso The Velvet Sundown ha fatto scuola per diversi motivi. Prima di tutto, ha dimostrato che la musica generata dall'AI può competere qualitativamente con quella prodotta da artisti umani, almeno dal punto di vista dell'ascolto casual. Suno, lanciata nel 2022 da ex ingegneri di OpenAI, utilizza reti neurali addestrate su milioni di canzoni di tutti i generi, permettendo di creare composizioni che rispettano le convenzioni musicali pur mantenendo elementi di originalità.</p>
-
 <p>Ma forse l'aspetto più interessante del progetto è la sua dimensione concettuale. Gli ideatori hanno trasformato quello che poteva essere un semplice esperimento tecnologico in una riflessione artistica sull'autenticità e sulla percezione della musica nell'era digitale. La band è diventata uno "specchio" che riflette i nostri pregiudizi e le nostre aspettative riguardo alla creatività. Quanti di quei 500.000 ascoltatori mensili avrebbero continuato ad apprezzare la musica se avessero saputo fin dall'inizio della sua origine artificiale?</p>
-
 <p>L'evoluzione della strategia comunicativa di The Velvet Sundown è stata particolarmente raffinata. Inizialmente, quando venivano poste domande dirette sulla natura del progetto, i responsabili negavano o eludevano il tema dell'intelligenza artificiale. Questa fase di "nascondimento" è durata abbastanza a lungo da permettere alla musica di trovare il suo pubblico basandosi esclusivamente sul proprio valore intrinseco. Solo quando la base di ascolti si era consolidata, è arrivata la rivelazione, accompagnata da una riflessione più ampia sul significato dell'autenticità nella musica contemporanea.</p>
-
 <p>Il successo di The Velvet Sundown ha anche evidenziato le potenzialità creative degli strumenti di AI musicale attuali. Nel marzo 2024, Suno ha rilasciato la versione V3 per tutti gli utenti, permettendo di creare brani di 4 minuti con account gratuiti, mentre la versione 4.5+ introduce "strumenti di produzione audio professionale mai visti prima". Questa rapida evoluzione tecnologica sta rendendo sempre più accessibile la creazione di musica di qualità professionale.</p>
-
 <h2>Iam: la prima cantante AI italiana</h2>
-
 <p>Parallelamente al fenomeno internazionale di The Velvet Sundown, l'Italia ha visto nascere il suo primo caso emblematico di artista musicale completamente artificiale. Iam, la cantante virtuale creata dal regista Claudio Zagarini in collaborazione con il collettivo Artificial Intelligence Italian Creators (AIIC), rappresenta un approccio diverso ma altrettanto significativo all'integrazione dell'AI nella musica.</p>
-
 <p>Il progetto Iam nasce nell'aprile 2025 con un obiettivo dichiaratamente sperimentale: creare non solo musica artificiale, ma un vero e proprio personaggio pubblico digitale. A differenza di The Velvet Sundown, che ha mantenuto un profilo misterioso, Iam è stata presentata fin dall'inizio come un'artista AI, con tanto di interviste, presenza sui social media e una personalità definita attraverso algoritmi di conversazione avanzati.</p>
-
 <p>Il singolo d'esordio "Pazzesco" ha immediatamente catturato l'attenzione dei media italiani, non solo per la qualità della produzione ma anche per il modo in cui è stato presentato al pubblico. Il brano mescola sonorità pop contemporanee con influenze elettroniche, creando un sound che risulta familiare ma al tempo stesso innovativo. La voce di Iam, generata attraverso sistemi di sintesi vocale avanzati, possiede caratteristiche distintive che la rendono riconoscibile e memorabile.</p>
-
 <p>Quello che rende unico il progetto Iam è l'approccio narrativo che lo accompagna. La cantante virtuale è stata dotata di una biografia, di preferenze musicali, di opinioni artistiche e persino di stranezze personali che emergono durante le interviste. Questo ha creato un fenomeno curioso: il pubblico si trova a interagire con un'intelligenza artificiale che non solo crea musica, ma che può anche parlarne, spiegare le proprie scelte creative e rispondere alle domande dei giornalisti.</p>
-
-<p><img src="Iam.jpg" alt="Iam.jpg" /></p>
-
+<p><img alt="Iam.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/08-AI Musica e Copyright/Iam.jpg"/></p>
 <p><em><a href="https://youtu.be/EspBah8iUJQ?si=pJPgGqsy62BO0v8W">Immagine tratta dal video YouTube "Pazzesco"</a></em></p>
-
 <p>L'impatto mediatico di Iam è stato significativo proprio per questa sua capacità di "esistere" come personaggio pubblico. Le interviste rilasciate dalla cantante AI hanno suscitato reazioni contrastanti: da un lato fascino per le capacità tecnologiche dimostrate, dall'altro inquietudine per la naturalezza con cui l'artificiale si presenta come autentico. Claudio Zagarini e il team di AIIC hanno dichiarato che l'obiettivo non è ingannare il pubblico, ma esplorare le possibilità espressive offerte dalle nuove tecnologie e stimolare una riflessione critica sul futuro dell'intrattenimento.</p>
-
 <p>Il confronto con il panorama musicale italiano tradizionale ha evidenziato alcuni aspetti interessanti. Mentre la scena musicale italiana è spesso caratterizzata da un forte attaccamento alla tradizione e da una certa resistenza alle innovazioni più radicali, l'accoglienza riservata a Iam ha mostrato un'apertura inaspettata verso l'sperimentazione tecnologica. Critici e addetti ai lavori si sono divisi tra entusiasti sostenitori dell'innovazione e conservatori preoccupati per l'impatto sulla creatività umana.</p>
-
 <p>Il progetto Iam ha anche sollevato questioni specifiche relative al contesto culturale italiano. Come si inserisce un'artista artificiale in una tradizione musicale fortemente legata all'identità territoriale e all'esperienza vissuta? Può un algoritmo catturare e reinterpretare le sfumature culturali che rendono unica la musica italiana? Queste domande sono diventate centrali nel dibattito che ha accompagnato il lancio del progetto.</p>
-
 <h2>Aspetti tecnici e creativi: come nasce la musica AI</h2>
-
 <p>Per comprendere appieno il fenomeno della musica generata dall'intelligenza artificiale, è necessario esplorare le tecnologie che rendono possibile questi risultati. Il processo di creazione musicale attraverso l'AI coinvolge diverse tecniche sofisticate, dalla text-to-audio generation alla sintesi vocale avanzata, passando per l'analisi e la ricombinazione di pattern musicali esistenti.</p>
-
 <p>Suno AI è una piattaforma di creazione musicale con intelligenza artificiale generativa, progettata per consentire agli utenti di generare canzoni realistiche che incorporano sia voce che strumentazione basate su prompt di testo. Il processo inizia con una descrizione testuale del brano desiderato: genere musicale, atmosfera, tematiche liriche, strumentazione preferita. L'algoritmo analizza questi input e genera una composizione completa che include melodie, armonie, ritmi e, quando richiesto, testi e performance vocali.</p>
-
 <p>La tecnologia sottostante si basa su reti neurali profonde addestrate su enormi database musicali. Suno è diverso da altri generatori musicali AI perché può creare canzoni complete con canto, parole e persino una copertina per l'album. Questo addestramento permette all'AI di riconoscere pattern musicali, strutture compositive e convenzioni stilistiche tipiche di diversi generi musicali, per poi ricombinarle in modi nuovi e creativamente interessanti.</p>
-
 <p>Un aspetto particolarmente avanzato è la capacità di generare performance vocali convincenti. La sintesi vocale utilizzata in questi sistemi va ben oltre la semplice conversione testo-parlato. Gli algoritmi sono in grado di interpretare il contenuto emotivo dei testi e di modulare di conseguenza timbro, intonazione, dinamiche e articolazione vocale. Il risultato sono performance che trasmettono emozioni e sfumature espressive paragonabili a quelle di cantanti umani.</p>
-
 <p>Una caratteristica avanzata permette agli utenti di prendere suoni del mondo reale—come rumore ambientale, parole parlate o ritmi semplici—e trasformarli in composizioni musicali complete. Questa funzionalità apre possibilità creative inedite, permettendo di trasformare qualsiasi input sonoro in materiale musicale strutturato.</p>
-
 <p>Tuttavia, è importante sottolineare che dietro ogni brano generato dall'AI c'è sempre un elemento di "direzione creativa umana". Nel caso di The Velvet Sundown e Iam, i risultati finali sono il frutto di un processo iterativo in cui gli operatori umani guidano l'AI attraverso prompt sempre più specifici, selezionano i risultati migliori e spesso li elaborano ulteriormente attraverso software di produzione musicale tradizionali.</p>
-
 <p>Questo solleva una questione fondamentale: quanto è davvero "artificiale" questa musica? Il processo creativo, seppur mediato dalla tecnologia, mantiene elementi di intuizione, gusto e scelta artistica tipicamente umani. Gli ideatori di questi progetti descrivono il loro ruolo come quello di "direttori creativi" che utilizzano l'AI come uno strumento, seppur molto avanzato, per realizzare le proprie visioni artistiche.</p>
-
 <p>I limiti attuali della tecnologia sono ancora evidenti in diversi ambiti. La coerenza narrativa nei testi lunghi, la capacità di creare progressioni musicali complesse e l'interpretazione di sfumature culturali specifiche rappresentano ancora sfide significative. Tuttavia, l'evoluzione è rapidissima: alla fine del 2024, Suno ha lanciato una campagna promozionale con Timbaland, uno dei produttori hip hop più influenti, segnalando un crescente riconoscimento da parte dell'industria musicale professionale.</p>
-
 <h2>Le reazioni del settore: voci dal mondo della musica</h2>
-
 <p>L'emergere di progetti come The Velvet Sundown e Iam ha scatenato reazioni contrastanti all'interno dell'industria musicale, rivelando divisioni profonde tra chi vede nell'AI un'opportunità rivoluzionaria e chi la considera una minaccia esistenziale per l'arte musicale.</p>
-
 <p>Le reazioni degli artisti si sono polarizzate lungo linee prevedibili ma non per questo meno significative. Musicisti e creativi argomentano che la musica creata dall'AI manca degli elementi essenziali della creatività umana, come emozione, esperienza vissuta e contesto culturale. Il compositore premio Grammy Hans Zimmer, che ha sperimentato con musica assistita dall'AI, sostiene che l'AI non possa replicare la profondità emotiva che deriva dall'esperienza umana diretta.</p>
-
 <p>Dall'altro lato dello spettro, un numero crescente di artisti sta abbracciando queste tecnologie come strumenti creativi. Alcuni musicisti emergenti hanno iniziato a utilizzare l'AI come collaboratore creativo, generando idee iniziali che poi sviluppano e raffinano attraverso processi tradizionali. Questa approccio ibrido sta creando un nuovo paradigma creativo che combina l'efficienza algoritmica con l'intuizione artistica umana.</p>
-
 <p>Le piattaforme di streaming si trovano ad affrontare sfide inedite. Spotify, Apple Music e altre major del settore devono sviluppare politiche per gestire contenuti generati dall'AI, bilanciando l'innovazione tecnologica con la protezione degli interessi degli artisti tradizionali. Alcune piattaforme stanno sperimentando con etichettature specifiche per i contenuti AI-generated, mentre altre preferiscono mantenere un approccio neutrale lasciando che sia il mercato a decidere.</p>
-
 <p>Centinaia di artisti hanno firmato una lettera aperta che mette in guardia contro l'uso "predatorio" dell'AI nella musica, chiedendo alle compagnie tecnologiche di non utilizzare l'intelligenza artificiale per violare i diritti degli artisti umani. Questa iniziativa, promossa dall'Artist Rights Alliance, evidenzia le preoccupazioni crescenti riguardo all'impatto economico dell'AI sulla comunità artistica.</p>
-
 <p>Il pubblico, dal canto suo, mostra reazioni complesse e spesso contraddittorie. Mentre molti ascoltatori apprezzano la musica AI quando non ne conoscono l'origine, la rivelazione della natura artificiale spesso porta a una rivalutazione critica. Tuttavia, una parte crescente del pubblico, specialmente tra le generazioni più giovani, mostra maggiore apertura verso l'innovazione tecnologica in ambito artistico.</p>
-
 <p>I critici musicali si trovano in una posizione particolarmente delicata. Come valutare artisticamente un brano che non nasce dalla creatività umana tradizionale? Quali criteri utilizzare per giudicare l'autenticità e il valore estetico di musica generata algoritmicamente? Alcune pubblicazioni specializzate hanno iniziato a sviluppare nuovi framework critici specificamente pensati per l'era dell'AI musicale.</p>
-
 <p>Gli esperti di marketing nell'industria musicale identificano tre principali conclusioni: l'uso etico della musica generata dall'AI è scalabile, ci troviamo nel "Far West" di questa tecnologia dove le decisioni prese ora determineranno i precedenti per il futuro, e creare musica con l'AI può essere divertente. Questa prospettiva pragmatica evidenzia come il settore stia gradualmente adattandosi alla nuova realtà tecnologica.</p>
-
 <h2>La dimensione etica: autenticità, diritti e creatività</h2>
-
 <p>Le implicazioni etiche dell'AI musicale sollevano questioni fondamentali che vanno al cuore stesso della creatività artistica e dell'industria dell'intrattenimento. Il caso di The Velvet Sundown, con la sua iniziale strategia di nascondere l'origine artificiale della musica, ha evidenziato il problema della trasparenza verso il pubblico. È etico permettere agli ascoltatori di sviluppare connessioni emotive con musica artificiale senza che ne siano consapevoli?</p>
-
 <p>La questione solleva domande sull'autenticità della forma d'arte. Alcuni argomentano che la musica generata dall'AI manca della profondità emotiva e dell'espressione personale che possiede la musica creata dagli umani. Questa posizione, pur comprensibile, apre a sua volta interrogativi più profondi: cosa definisce l'autenticità in un'epoca in cui la maggior parte della musica commerciale è già pesantemente mediata dalla tecnologia?</p>
-
 <p>Il concetto di creatività si trova al centro del dibattito etico. La creatività è una prerogativa esclusivamente umana o può essere replicata e persino superata da sistemi artificiali? I progetti come Iam e The Velvet Sundown suggeriscono che l'AI può produrre risultati creativi che risuonano emotivamente con il pubblico, indipendentemente dalla loro origine non umana. Questo potrebbe indicare che la creatività è più un processo di ricombinazione innovativa di elementi esistenti piuttosto che una misteriosa scintilla divina esclusivamente umana.</p>
-
 <p>Le questioni di copyright e diritti d'autore rappresentano un terreno minato legale ed etico. Gli sviluppatori di AI musicale devono dare priorità a pratiche di licenziamento etico e collaborare strettamente con compositori e proprietari di copyright. Ma come si definiscono i diritti su musica generata da algoritmi addestrati su milioni di brani esistenti? Chi possiede il copyright di una canzone AI: il programmatore dell'algoritmo, l'utente che ha fornito il prompt, o nessuno?</p>
-
 <p>Una decisione della corte statunitense ha stabilito che le composizioni completamente generate dall'AI - dove un artista semplicemente preme un pulsante e lascia che l'AI crei una canzone dall'inizio alla fine - non possono essere coperte da copyright. Questo mette i brani puramente generati dall'AI nel dominio pubblico, rendendoli liberamente disponibili per l'uso o la riproduzione da parte di chiunque. La distinzione cruciale è il livello di input umano: l'Ufficio Copyright degli Stati Uniti ha stabilito che "il tocco umano fa tutta la differenza", ma ci sono distinzioni importanti da considerare.</p>
-
 <p>Il Tennessee ha approvato l'ELVIS Act (Ensuring Likeness Voice and Image Security Act), la prima legge statunitense che protegge i musicisti dall'uso non autorizzato dell'intelligenza artificiale, aggiornando la legge sulla Protection of Personal Rights dello stato per includere protezioni per voce e immagine. Una volta che la legge è entrata in vigore il 1° luglio 2024, sarà proibito utilizzare l'AI per imitare la voce di un artista senza permesso. Ma la tecnologia, abile nel copiare voci e stili di artisti reali, si muove troppo velocemente perché una singola legge possa stare al passo. Questa corsa tra innovazione tecnologica e regolamentazione legale evidenzia la necessità di framework etici e legali più agili e adattabili.</p>
-
 <p>L'impatto sui musicisti professionisti è forse l'aspetto etico più immediato e concreto. La ricerca identifica due questioni urgenti: l'inevitabile aumento della popolazione artistica in eccedenza e la diminuzione del costo del lavoro creativo. Se l'AI può produrre musica di qualità commerciale a costi marginali, quale sarà il futuro economico per musicisti, compositori e produttori?</p>
-
 <p>Tuttavia, non tutti gli scenari sono necessariamente negativi. Alcuni esperti propongono un modello di collaborazione uomo-macchina dove l'AI amplifica le capacità creative umane piuttosto che sostituirle. In questo scenario, i musicisti potrebbero utilizzare l'AI per esplorare nuove direzioni creative, superare blocchi compositivi o realizzare progetti che altrimenti richiederebbero risorse proibitive.</p>
-
 <p>Organizzazioni come Sound Ethics stanno "abbracciando l'AI nell'industria musicale proteggendo e sostenendo gli artisti, assicurando le nostre carriere future. Attraverso partnership con istituzioni educative, esperti legali e stakeholder, stiamo stabilendo nuovi standard e promuovendo politiche che proteggano i diritti degli artisti".</p>
-
 <p>La democratizzazione della creazione musicale presenta sia opportunità che rischi etici. Da un lato, l'AI può permettere a persone senza formazione musicale formale di esprimere la propria creatività e raggiungere un pubblico globale. Dall'altro, questa facilità di accesso potrebbe portare a una saturazione del mercato musicale con contenuti di qualità variabile, rendendo ancora più difficile per gli artisti emergere.</p>
-
 <p>La questione della diversità culturale è altrettanto complessa. Gli algoritmi di AI musicale sono addestrati principalmente su musica occidentale commerciale, rischiando di perpetuare bias culturali e di omologare l'espressione musicale globale. Come garantire che l'AI non diventi uno strumento di standardizzazione culturale ma mantenga e celebri la diversità delle tradizioni musicali mondiali?</p>
-
 <h2>Scenari futuri: verso dove va la musica AI</h2>
-
 <p>L'evoluzione tecnologica nel campo dell'AI musicale procede a ritmi accelerati, suggerendo scenari futuri che potrebbero trasformare radicalmente l'industria dell'intrattenimento nei prossimi anni. Le previsioni degli esperti del settore delineano possibilità tanto affascinanti quanto inquietanti per il futuro della creazione musicale.</p>
-
 <p>Dal punto di vista puramente tecnologico, i miglioramenti attesi sono significativi. Entro il 2026-2027, è probabile che vedremo sistemi di AI musicale capaci di creare composizioni di durata estesa mantenendo coerenza narrativa e sviluppo tematico. L'integrazione con tecnologie di realtà virtuale e aumentata potrebbe permettere esperienze musicali immersive dove l'AI genera colonne sonore in tempo reale basandosi sulle emozioni e i comportamenti dell'utente.</p>
-
 <p>L'evoluzione recente di Suno, con partnership con produttori di primo piano come Timbaland, suggerisce una transizione da strumento per dilettanti a piattaforma professionale. Questo trend potrebbe portare all'emergere di nuove figure professionali: i "direttori creativi AI" che specializzano nella guida algoritmica per produzioni musicali commerciali.</p>
-
 <p>Lo scenario ottimistico prevede l'AI come amplificatore della creatività umana. In questa visione, musicisti e produttori utilizzeranno l'intelligenza artificiale come un collaboratore inesauribile, capace di suggerire infinite variazioni, esplorare territori sonori inesplorati e realizzare arrangiamenti complessi in tempi record. Piccole etichette discografiche potrebbero competere con le major grazie alla democratizzazione degli strumenti di produzione. Artisti indipendenti potrebbero creare album completi con budget limitati, concentrandosi sulla visione creativa mentre l'AI gestisce gli aspetti tecnici più complessi.</p>
-
 <p>In questo scenario positivo, emergerebbe una nuova economia creativa dove il valore si sposta dalla capacità tecnica alla visione artistica e alla capacità di connessione emotiva con il pubblico. Gli artisti umani potrebbero specializzarsi in performance live, narrative concettuali e esperienze artistiche che l'AI non può replicare, mentre l'intelligenza artificiale gestisce la produzione di massa e la creazione di contenuti personalizzati.</p>
-
 <p>Tuttavia, lo scenario pessimistico presenta rischi considerevoli. La facilità di produzione potrebbe portare a una saturazione del mercato musicale con contenuti algoritmici di qualità media, rendendo sempre più difficile per gli artisti umani emergere e mantenere sostenibilità economica. La standardizzazione algoritmica potrebbe omologare i gusti musicali, riducendo la diversità stilistica e culturale che ha sempre caratterizzato l'arte musicale.</p>
-
 <p>Un rischio particolare è rappresentato dalla possibile perdita di connessione tra artista e pubblico. Se la musica diventa principalmente un prodotto algoritmico ottimizzato per il massimo engagement, potremmo perdere quella dimensione di vulnerabilità e autenticità umana che ha sempre costituito il cuore dell'esperienza musicale. La musica potrebbe trasformarsi da forma di espressione artistica a prodotto di consumo ottimizzato per algoritmi di raccomandazione.</p>
-
 <p>La questione della regolamentazione diventerà cruciale. Sarà necessario sviluppare framework legali che bilancino l'innovazione tecnologica con la protezione dei diritti degli artisti e la trasparenza verso i consumatori. Alcuni paesi potrebbero richiedere l'etichettatura obbligatoria dei contenuti AI-generated, mentre altri potrebbero adottare approcci più liberisti. Negli Stati Uniti, è stato proposto il Generative AI Copyright Disclosure Act del 2024, che richiederebbe alle aziende che sviluppano AI generativa di rivelare i dataset utilizzati per l'addestramento. Le etichette discografiche che detengono contratti con artisti potrebbero intraprendere azioni legali contro le parti che infrangono i diritti, benché questi rimedi siano attualmente limitati geograficamente.</p>
-
 <p>L'educazione musicale dovrà necessariamente evolversi. Le scuole di musica e i conservatori dovranno integrare l'AI nei loro curricula, insegnando agli studenti non solo a suonare strumenti e comporre, ma anche a collaborare efficacemente con sistemi intelligenti. Emergeranno nuove discipline come la "direzione creativa algoritmica" e l'"ingegneria dell'esperienza musicale AI".</p>
-
 <p>Il modello di business dell'industria musicale subirà trasformazioni profonde. Potrebbero emergere servizi di "musica su richiesta" dove gli utenti commissionano brani personalizzati per occasioni specifiche. Le playlist potrebbero diventare composizioni algoritmiche in tempo reale, adattandosi dinamicamente all'umore e alle attività dell'ascoltatore.</p>
-
 <h2>Conclusioni: l'inevitabilità del cambiamento</h2>
-
 <p>L'analisi dei casi The Velvet Sundown e Iam rivela che l'integrazione dell'intelligenza artificiale nella musica non è più una prospettiva futura, ma una realtà presente che sta già ridefinendo i paradigmi creativi e commerciali dell'industria. Questi progetti pionieristici hanno dimostrato che l'AI può produrre musica non solo tecnicamente competente, ma emotivamente coinvolgente e commercialmente vitale.</p>
-
 <p>La vera lezione che emerge da questa rivoluzione silenziosa è che il valore della musica non risiede esclusivamente nella sua origine umana, ma nella sua capacità di connettersi con l'esperienza emotiva degli ascoltatori. The Velvet Sundown ha conquistato mezzo milione di ascoltatori mensili prima che qualcuno scoprisse la sua natura artificiale. Iam ha generato discussioni appassionate sui media italiani non solo come curiosità tecnologica, ma come fenomeno artistico autentico.</p>
-
 <p>Tuttavia, questa trasformazione solleva questioni etiche che richiedono risposte ponderate. La trasparenza verso il pubblico, la protezione dei diritti degli artisti umani, la preservazione della diversità culturale e la sostenibilità economica del settore musicale sono sfide che richiedono l'impegno coordinato di tecnologi, artisti, regolatori e società civile.</p>
-
 <p>L'evoluzione in corso suggerisce che il futuro della musica non sarà necessariamente una sostituzione dell'umano con l'artificiale, ma piuttosto una riarticolazione dei ruoli creativi dove intelligenza umana e artificiale collaborano in modi nuovi e inediti. Gli artisti del futuro potrebbero non essere sostituiti dall'AI, ma dovranno imparare a lavorare con essa, utilizzandola come uno strumento per amplificare le proprie capacità creative.</p>
-
 <p>La democratizzazione della creazione musicale offerta dall'AI presenta opportunità straordinarie per l'espressione creativa, permettendo a persone senza formazione musicale formale di dare vita alle proprie visioni artistiche. Allo stesso tempo, questa accessibilità richiede nuovi criteri per valutare la qualità e l'originalità in un mondo dove chiunque può produrre musica professionale con pochi click.</p>
-
 <p>Il cambiamento è inevitabile, ma la sua direzione non è predeterminata. Le scelte che facciamo oggi - come società, come industria, come consumatori - determineranno se l'AI musicale diventerà uno strumento di liberazione creativa o di standardizzazione commerciale, se amplierà la diversità artistica o la ridurrà, se supporterà gli artisti umani o li sostituirà.</p>
-
 <p>La storia di The Velvet Sundown e Iam è appena iniziata. Rappresentano i primi capitoli di una trasformazione che continuerà a evolversi nei prossimi anni, sfidando le nostre concezioni di creatività, autenticità e valore artistico. Il loro successo ci ricorda che, in ultima analisi, la musica che conta è quella che riesce a toccare l'anima umana, indipendentemente dalla sua origine. La sfida per il futuro sarà garantire che questa capacità di connessione emotiva non vada perduta nella transizione verso l'era dell'intelligenza artificiale musicale.</p>
-
 <p>Nel frattempo, le "fondamenta del copyright nella musica come la conosciamo" continuano a essere scosse dalla rapida evoluzione dell'AI, in un momento in cui l'industria musicale è al centro del dibattito sulla proprietà intellettuale globale. La partita è appena iniziata, e le regole del gioco stanno ancora prendendo forma.</p>
-
 <h2>Resurrezione digitale: far cantare chi non c'è più</h2>
-
 <p>Visto l'argomento, ho ritenuto giusto metterlo dopo le conclusioni, immagino capirete l'ironico perché. Vorrei infatti accennarvi dell'ultima "frontiera" dell'intelligenza artificiale musicale: far "resuscitare" digitalmente artisti morti da decenni per far loro cantare nuove canzoni.</p>
-
 <p>Il caso è esploso solo pochi giorni fa quando una canzone intitolata "Together" è apparsa sulla pagina ufficiale Spotify di Blaze Foley, cantautore country assassinato nel 1989, seguita da "Happened To You" attribuita a Guy Clark, Grammy winner scomparso nel 2016.</p>
-
 <p>I brani, marcati con il copyright di una misteriosa "Syntax Error" e caricati tramite la piattaforma SoundOn di TikTok senza autorizzazione di eredi o etichette, hanno scatenato polemiche feroci prima di essere rimossi.</p>
-
 <p>Craig McDonald, proprietario dell'etichetta che gestisce il catalogo di Foley, ha scoperto casualmente la pubblicazione non autorizzata, sollevando interrogativi inquietanti sui limiti etici di questa tecnologia.</p>
-
 <p>Se già discutiamo di trasparenza e autenticità con artisti AI "vivi e vegeti", immaginate le implicazioni quando si tratta di far cantare i morti senza il loro consenso. Evidentemente, nell'era dell'intelligenza artificiale, nemmeno la morte rappresenta più un limite alla carriera discografica.</p>
-
 <p>Ma questa è un'altra storia che meriterebbe un articolo a parte, magari intitolato "Quando l'AI incontra l'aldilà: guida pratica alla necromanzia digitale".</p>
 
             <div class="footer-back-button">

--- a/dist/09 - AI Kimi K2 il nuovo sfidante.html
+++ b/dist/09 - AI Kimi K2 il nuovo sfidante.html
@@ -162,78 +162,43 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>Kimi K2: L'Intelligenza Artificiale Cinese che Sfida i Giganti del Coding</h1>
-
 <p><em>di Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="DavideGolia_IA.jpg" alt="DavideGolia_IA.jpg" /></p>
-
+<img alt="DavideGolia_IA.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/09 - AI Kimi K2 il nuovo sfidante/DavideGolia_IA.jpg"/></p>
 <p><em>Se l'intelligenza artificiale fosse una serie Netflix, diremmo che siamo arrivati al momento in cui il protagonista incontrastato si trova davanti a un nuovo rivale che nessuno si aspettava. Dopo anni di dominio americano nel settore dell'AI, con OpenAI e Anthropic a farla da padroni, dall'Oriente arriva un challenger che promette di rimescolare le carte: Kimi K2, l'ultima creazione di Moonshot AI.</em></p>
-
 <h2>Il David cinese contro i Golia di Silicon Valley</h2>
-
 <p>Per capire l'importanza di questa novità, bisogna fare un passo indietro. Moonshot AI non è esattamente una startup garage: fondata nel 2023 dall'ex ricercatore di Tsinghua University Yang Zhilin, l'azienda ha già dimostrato le sue credenziali nel mercato cinese. Il loro precedente chatbot Kimi è riuscito a conquistare il terzo posto tra i più utilizzati in Cina, secondo i <a href="https://www.nature.com/articles/d41586-025-02275-6">dati di Counterpoint Research</a>, posizionandosi subito dietro ai giganti Baidu e ByteDance. Non male per un'azienda così giovane, soprattutto considerando che ha alle spalle il supporto strategico di Alibaba.</p>
-
 <p>Ma Kimi K2 non è semplicemente un aggiornamento del precedente modello: è un salto quantico che punta dritto al cuore del mercato globale. Come riporta <a href="https://venturebeat.com/ai/moonshot-ais-kimi-k2-outperforms-gpt-4-in-key-benchmarks-and-its-free/">VentureBeat</a>, questo nuovo modello utilizza un'architettura chiamata "mixture-of-experts" (MoE), una tecnologia che possiamo immaginare come un team di specialisti altamente qualificati. Invece di avere un singolo "cervello" che cerca di fare tutto, Kimi K2 dispone di 1 trilione di parametri totali, di cui 32 miliardi vengono attivati in base al compito specifico. È come avere una redazione dove ogni giornalista è esperto in un settore diverso, e per ogni articolo viene chiamato in causa solo chi sa davvero di cosa sta parlando.</p>
-
 <h2>I numeri che fanno tremare la concorrenza</h2>
-
 <p>Le prestazioni di Kimi K2 raccontano una storia interessante, specialmente quando si parla di programmazione. Nel benchmark SWE-bench Verified, considerato uno dei test più difficili per valutare le capacità di coding dell'AI, il modello cinese ha raggiunto il 65.8% di accuratezza alla prima prova, salendo al 71.6% con tentativi multipli. Per mettere questi numeri in prospettiva, stiamo parlando di un modello che riesce a risolvere problemi reali di programmazione presi direttamente da GitHub, superando GPT-4.1 e arrivando a competere con Claude 4 Opus di Anthropic.
-<img src="Kimi-K2-Benchmark-Graphic.jpg" alt="Kimi-K2-Benchmark-Graphic.jpg" />
+<img alt="Kimi-K2-Benchmark-Graphic.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/09 - AI Kimi K2 il nuovo sfidante/Kimi-K2-Benchmark-Graphic.jpg"/>
 <em><a href="https://moonshotai.github.io/Kimi-K2/">Immagine tratta dal sito di Moonshot AI</a></em></p>
-
 <p>Ma è nel confronto diretto con i modelli più celebrati che Kimi K2 mostra i muscoli. Come evidenziato da diverse analisi comparative pubblicate su <a href="https://www.cnbc.com/2025/07/14/alibaba-backed-moonshot-releases-kimi-k2-ai-rivaling-chatgpt-claude.html">CNBC</a> e piattaforme specializzate, in matematica il modello cinese raggiunge il 97.4% contro il 92.4% di GPT-4.1, mentre nel coding si attesta al 53.7% superando il 44.7% del modello OpenAI. Anche nel confronto con Claude 4 Sonnet, tradizionalmente considerato uno dei migliori per la programmazione, Kimi K2 dimostra prestazioni superiori nei benchmark di coding tramite agenti, pur mantenendo una velocità di output più bassa (34.1 token al secondo contro i 91.3 di Claude).</p>
-
 <h3>Sotto il cofano: come funziona davvero Kimi K2</h3>
-
 <p>Per capire davvero cosa rende Kimi K2 così speciale, bisogna aprire il cofano e dare un'occhiata al motore. Come spiegato nel <a href="https://github.com/MoonshotAI/Kimi-K2">repository ufficiale su GitHub</a>, l'architettura Mixture-of-Experts non è solo una moda tecnologica, ma una soluzione intelligente a un problema concreto: come ottenere le prestazioni di un modello gigantesco senza dover attivare ogni volta tutti i suoi "neuroni".</p>
-
 <p>Immaginate Kimi K2 come un grande ospedale con 384 specialisti diversi. Quando arriva un paziente con un problema al cuore, non serve chiamare anche l'ortopedico e il dermatologo: basta attivare il cardiologo e pochi altri colleghi pertinenti. Così funziona il sistema MoE di Kimi K2: dei suoi 1 trilione di parametri totali, <a href="https://www.llmwatch.com/p/kimi-k2-what-it-is-how-it-works-and">solo 32 miliardi vengono "accesi" per ogni singola richiesta</a>, rendendo il calcolo molto più efficiente.</p>
-
 <p>Ma c'è di più: come documentato dal <a href="https://console.groq.com/docs/model/moonshotai/kimi-k2-instruct">team di GroqDocs</a>, Kimi K2 utilizza un'architettura transformer avanzata che ottimizza specificamente la comprensione del codice. È come avere un traduttore che non solo capisce diverse lingue, ma è anche specializzato nei dialetti tecnici di ogni linguaggio di programmazione.</p>
-
 <p>La finestra di contesto da 128.000 token rappresenta un altro salto qualitativo rispetto ai modelli tradizionali. In termini pratici, significa che Kimi K2 può "tenere a mente" l'equivalente di circa 200-300 pagine di testo contemporaneamente. Per un programmatore, questo si traduce nella capacità di analizzare intere applicazioni, comprendere le relazioni tra diversi file e moduli, e suggerire modifiche che tengano conto dell'architettura complessiva del progetto.</p>
-
 <h2>L'arma segreta: gratuito e open source</h2>
-
 <p>Se le prestazioni tecniche impressionano, è la strategia commerciale a rendere Kimi K2 potenzialmente rivoluzionario. Mentre GPT-4 e Claude richiedono abbonamenti costosi, Kimi K2 è completamente gratuito e disponibile tramite app e browser. È un po' come se Netflix decidesse improvvisamente di rendere tutto il suo catalogo gratuito: cambierebbe completamente le regole del gioco.</p>
-
 <p>L'approccio open source di Moonshot AI non è solo una mossa commerciale, ma una vera e propria filosofia. Come sottolineato dal <a href="https://moonshotai.github.io/Kimi-K2/">sito ufficiale dell'azienda</a>, l'obiettivo è democratizzare l'accesso all'intelligenza artificiale avanzata, permettendo a ricercatori, sviluppatori e aziende di tutto il mondo di sperimentare con tecnologie all'avanguardia senza barriere economiche. È una strategia che ricorda quella di Google con Android: offrire gratuitamente una tecnologia eccellente per conquistare quote di mercato e creare un ecosistema.</p>
-
 <h2>La rivoluzione del coding assistito</h2>
-
 <p>Quello che rende Kimi K2 particolarmente interessante è la sua specializzazione nel "tool calling" e nell'esecuzione multi-step, caratteristiche fondamentali per quello che gli esperti chiamano "agentic coding". In parole semplici, mentre i chatbot tradizionali si limitano a rispondere alle domande, Kimi K2 può effettivamente "fare" cose: eseguire codice, interagire con strumenti esterni, e portare avanti progetti complessi in modo autonomo.</p>
-
 <p>Questa capacità ha attirato l'attenzione della community internazionale degli sviluppatori. Come documentato in diversi blog tecnici, alcuni programmatori stanno già sperimentando l'integrazione di Kimi K2 con strumenti come Claude Code di Anthropic, creando combinazioni ibride che sfruttano i punti di forza di entrambi i sistemi. È un approccio pragmatico che dimostra come, nel mondo reale, la competizione tra AI possa trasformarsi in collaborazione.</p>
-
 <h3>Kimi K2 all'opera: storie dal campo</h3>
-
 <p>Ma come si comporta Kimi K2 quando scende nell'arena della programmazione reale? Le prime testimonianze dai laboratori di sviluppo raccontano una storia affascinante. Il team di <a href="https://cline.bot/blog/moonshots-kimi-k2-for-coding-our-first-impressions-in-cline">Cline ha documentato le loro prime impressioni</a> con risultati sorprendenti: "Kimi K2 si è dimostrato particolarmente forte in modalità 'Act', dove eccelle nell'eseguire piani ben definiti piuttosto che nella pianificazione iniziale".</p>
-
 <p>L'analisi della community di sviluppatori rivela pattern interessanti nell'utilizzo pratico. Come evidenziato su <a href="https://www.analyticsvidhya.com/blog/2025/07/kimi-k2/">Analytics Vidhya</a>, il modello dimostra una particolare abilità nel gestire "l'architettura avanzata di ragionamento" che permette di scomporre problemi complessi in fasi gestibili. Questo approccio si traduce in una maggiore accuratezza quando si tratta di debugging di codice multi-file e ottimizzazione di performance.</p>
-
 <p>Un caso emblematico arriva dal confronto diretto con altri modelli. <a href="https://garysvenson09.medium.com/how-to-run-kimi-k2-inside-claude-code-the-ultimate-open-source-ai-coding-combo-7b248adcf336">Gary Svenson ha documentato su Medium</a> come l'integrazione di Kimi K2 con Claude Code crei combinazioni ibride che sfruttano i punti di forza di entrambi i sistemi: "La potenza bruta di un modello da trillion parametri combinata con l'eleganza dell'interfaccia Claude Code".</p>
-
 <p>Nel benchmark SWE-bench Verified, che simula il lavoro di uno sviluppatore su problemi reali di GitHub, <a href="https://moonshotai.github.io/Kimi-K2/">Kimi K2 ha raggiunto il 65.8% di successo</a> al primo tentativo. Come spiega la documentazione ufficiale, questo test rappresenta una delle valutazioni più realistiche per misurare le capacità pratiche di coding dell'AI, poiché replica scenari di sviluppo autentici piuttosto che esercizi accademici.</p>
-
 <p>Particolarmente interessante è l'approccio collaborativo che alcuni team stanno sperimentando. La <a href="https://huggingface.co/blog/francesca-petracci/kimi-k2-claude-code">guida per sviluppatori su Hugging Face</a> documenta come "le capacità agentiche di Kimi K2 permettono di scomporre task complessi in passaggi più piccoli e gestibili, eseguendoli in modo autonomo". È una strategia che ricorda i pit-stop della Formula 1: ogni membro del team ha il suo ruolo specifico, e il risultato finale è superiore alla somma delle parti.</p>
-
 <p>La community di <a href="https://www.datacamp.com/tutorial/kimi-k2">DataCamp ha osservato</a> che "Kimi K2 offre capacità reali per sviluppatori disposti a sperimentare, particolarmente per chi cerca maggiore controllo sul comportamento agentico a costi contenuti". Non è solo marketing: stiamo assistendo alla nascita di nuovi workflow di sviluppo dove l'AI cinese si sta ritagliando una nicchia specifica ma importante nel panorama degli strumenti di programmazione assistita.</p>
-
 <h2>Le implicazioni geopolitiche dell'AI</h2>
-
 <p>L'emergere di Kimi K2 non è solo una questione tecnica, ma ha anche risvolti geopolitici significativi. Dopo anni in cui la Cina sembrava inseguire gli Stati Uniti nel campo dell'intelligenza artificiale, modelli come Kimi K2 dimostrano che il gap si sta rapidamente colmando. Non è un caso che il modello eccella proprio in aree cruciali come matematica e programmazione, competenze fondamentali per l'innovazione tecnologica del futuro.</p>
-
 <p>La strategia di rendere il modello gratuitamente accessibile può essere letta anche in questa chiave: conquistare utenti globali, raccogliere feedback, migliorare rapidamente e creare dipendenza tecnologica. È lo stesso playbook che ha permesso a TikTok di conquistare il mondo, applicato però a una tecnologia ben più strategica.</p>
-
 <h2>Il futuro che ci aspetta</h2>
-
 <p>Mentre scrivo questo articolo, Kimi K2 sta già dimostrando il suo potenziale in applicazioni reali. Gli sviluppatori che lo stanno testando riportano risultati impressionanti nella risoluzione di problemi complessi di programmazione, specialmente quando si tratta di debugging e ottimizzazione del codice. La capacità del modello di "pensare" in modo strutturato e di utilizzare strumenti esterni lo rende particolarmente adatto per progetti che richiedono un approccio metodico e paziente.</p>
-
 <p>Tuttavia, non tutto è perfetto. La velocità di risposta più bassa rispetto ai concorrenti può essere un limite in applicazioni real-time, e rimangono domande sulla sostenibilità economica di un modello così avanzato offerto gratuitamente. Come per ogni tecnologia emergente, sarà il tempo a dirci se Kimi K2 riuscirà a mantenere le promesse iniziali.</p>
-
 <h2>Conclusioni: una nuova era per l'AI</h2>
-
 <p>Kimi K2 rappresenta molto più di un semplice nuovo modello di intelligenza artificiale: è il simbolo di un cambiamento epocale nel settore tech. Per la prima volta, un'azienda non americana non solo compete ad armi pari con i leader mondiali, ma in alcuni ambiti li supera, offrendo tutto gratuitamente.</p>
-
 <p>Come in ogni buona storia di fantascienza che si rispetti, il futuro che ci aspetta sarà probabilmente diverso da quello che immaginiamo oggi. Quello che è certo è che la competizione globale nell'AI si è appena fatta molto più interessante, e noi sviluppatori e utenti finali non possiamo che beneficiarne. Dopotutto, come diceva un certo Spider-Man, "da grandi poteri derivano grandi responsabilità" – e Kimi K2 sembra pronto ad assumersi le sue.</p>
 
             <div class="footer-back-button">

--- a/dist/10 - AI Posti di Lavoro.html
+++ b/dist/10 - AI Posti di Lavoro.html
@@ -162,84 +162,46 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>L'Intelligenza Artificiale e il Futuro del Lavoro</h1>
-
 <p><em>di Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="work_wrestling.jpg" alt="work_wrestling.jpg" /></p>
-
+<img alt="work_wrestling.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/10 - AI Posti di Lavoro/work_wrestling.jpg"/></p>
 <p><em>Come in Matrix, siamo di fronte a una scelta: pillola rossa o blu? L'intelligenza artificiale sta arrivando nel mondo del lavoro e non possiamo più ignorarla.</em></p>
-
 <h2>La grande trasformazione: tra posti perduti e nuove opportunità professionali</h2>
-
 <p>La domanda che tiene svegli manager, sindacalisti e lavoratori di tutto il mondo è sempre la stessa: l'AI ci ruberà il lavoro o ne creerà di nuovi? La risposta, come spesso accade per le grandi trasformazioni tecnologiche, è più complessa di quanto sembri e merita di essere analizzata con dati concreti alla mano, lasciando da parte tanto gli apocalittici quanto i sognatori.</p>
-
 <p>Il dibattito sui posti di lavoro e l'intelligenza artificiale ha raggiunto un punto di svolta grazie a ricerche scientifiche che finalmente ci permettono di andare oltre le speculazioni. Non stiamo più parlando di previsioni fumose o scenari fantascientifici, ma di analisi basate sull'utilizzo reale che milioni di persone fanno quotidianamente di questi strumenti. I numeri che emergono da questi studi dipingono un quadro sorprendente, che ribalta molti dei nostri preconcetti sulla tecnologia e il futuro del lavoro.</p>
-
 <h2>I numeri della trasformazione</h2>
-
 <p>Il <a href="https://www.weforum.org/publications/the-future-of-jobs-report-2023/">Future of Jobs Report 2023 del World Economic Forum</a> ha analizzato 673 milioni di posti di lavoro a livello globale, fornendo la fotografia più completa mai realizzata sull'impatto dell'intelligenza artificiale nel mondo del lavoro. I risultati sono tanto illuminanti quanto inaspettati: mentre 83 milioni di posti di lavoro sono destinati a essere eliminati nei prossimi cinque anni a causa dell'automazione e dell'AI, ben 69 milioni di nuove posizioni nasceranno proprio grazie a queste tecnologie. Il saldo netto rimane leggermente negativo, ma si tratta di una contrazione molto più contenuta di quanto molti prevedessero.</p>
-
 <p>Ancora più interessante è l'approccio adottato dai ricercatori di Microsoft nello studio <a href="https://www.microsoft.com/en-us/research/publication/working-with-ai-measuring-the-occupational-implications-of-generative-ai/">"Working with AI: Measuring the Occupational Implications of Generative AI"</a>, guidato da Kiran Tomlinson. Per la prima volta, invece di basarsi su previsioni teoriche, gli studiosi hanno analizzato 200.000 conversazioni rese anonime tra utenti reali e Microsoft Bing Copilot. Questo approccio rivoluzionario ha permesso di creare un coefficiente scientifico chiamato "AI Applicability Score" che misura quanto l'intelligenza artificiale possa effettivamente aiutare o sostituire specifiche attività lavorative.</p>
-
 <p>La metodologia rigorosa adottata da Microsoft rappresenta un punto di svolta nella ricerca sull'impatto dell'AI. Invece di affidarsi a speculazioni o modelli teorici, i ricercatori hanno osservato cosa le persone fanno realmente quando interagiscono con l'intelligenza artificiale per scopi lavorativi. I risultati di questa analisi empirica sono sorprendenti e spesso controintuitivi rispetto alle previsioni tradizionali.</p>
-
 <p>La differenza fondamentale tra questi studi e le previsioni precedenti sta nella concretezza dell'approccio. Non stiamo più parlando di quello che l'AI potrebbe fare in teoria, ma di quello che sta già facendo nella pratica quotidiana di milioni di lavoratori. Questo cambio di prospettiva ha prodotto risultati che sfidano molte delle nostre certezze consolidate.</p>
-
 <h2>Chi rischia di più</h2>
-
 <p>I risultati dello <a href="https://www.microsoft.com/en-us/research/publication/working-with-ai-measuring-the-occupational-implications-of-generative-ai/">studio Microsoft</a> rivelano un paradosso che avrebbe fatto sorridere anche Isaac Asimov: i lavori più esposti all'intelligenza artificiale non sono quelli manuali che immaginavamo, ma le professioni legate a computer e matematica, supporto amministrativo e vendite che implicano fornire e comunicare informazioni. È come se Data di Star Trek si fosse rivelato più vulnerabile di Scotty, l'ingegnere che armeggiava con le mani nei condotti della nave Enterprise.</p>
-
 <p>L'analisi delle conversazioni reali ha mostrato che le attività più comuni per cui le persone chiedono assistenza all'AI sono la raccolta di informazioni e la scrittura, mentre l'intelligenza artificiale eccelle proprio nel fornire informazioni, scrivere, insegnare e consigliare. Questa sovrapposizione quasi perfetta spiega perché alcuni lavori "intellettuali" risultino più esposti di quanto ci aspettassimo.</p>
-
 <p>La questione della scolarizzazione emerge come particolarmente complessa. Contrariamente a quanto si potrebbe pensare, l'AI non colpisce solo i lavori meno qualificati, ma attraversa trasversalmente tutti i livelli di istruzione. Molti professionisti con lauree specialistiche si trovano paradossalmente più esposti di lavoratori con competenze tecniche specifiche e manuali. Questo ribalta completamente il paradigma tradizionale secondo cui la tecnologia avrebbe sempre privilegiato i più istruiti.</p>
-
 <p>I lavori più sicuri sono quelli che richiedono presenza fisica, abilità manuali specifiche e interazione diretta con l'ambiente. Gli idraulici, gli elettricisti, i meccanici, ma anche i chirurghi, gli infermieri e gli educatori dell'infanzia mantengono un vantaggio competitivo significativo rispetto all'intelligenza artificiale. La chiave sta nella combinazione di competenze motorie fini, capacità di adattamento a situazioni impreviste e interazione emotiva con le persone.</p>
-
 <p>Un aspetto particolarmente interessante emerso dalla ricerca è che il livello di salario non è necessariamente correlato con la sicurezza del posto. Alcuni lavori molto ben pagati, specialmente nel settore finanziario e della consulenza, mostrano punteggi di applicabilità dell'AI sorprendentemente alti. Al contrario, alcune professioni con retribuzioni medie o basse, ma che richiedono presenza fisica e problem-solving contestuale, risultano molto più protette.</p>
-
-<p><img src="job_exposure.jpg" alt="job_exposure.jpg" />
+<p><img alt="job_exposure.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/10 - AI Posti di Lavoro/job_exposure.jpg"/>
 <em><a href="https://www.weforum.org/stories/2023/09/jobs-ai-will-create/">Immagine tratta dal sito di World Economic Forum</a></em></p>
-
 <h2>Le nuove opportunità</h2>
-
 <p>Mentre alcuni settori si contraggono, altri esplodono letteralmente. Le professioni emergenti identificate dal <a href="https://www.weforum.org/stories/2023/09/jobs-ai-will-create/">World Economic Forum</a> vanno ben oltre i classici sviluppatori di software. Stiamo vedendo nascere specialisti in machine learning, ingegneri dell'AI, consulenti per l'implementazione dell'intelligenza artificiale, ma anche figure ibride che combinano competenze tradizionali con la capacità di collaborare efficacemente con i sistemi intelligenti.</p>
-
 <p>I settori con la crescita occupazionale più alta nel periodo 2023-2027, secondo il <a href="https://www.weforum.org/stories/2023/05/jobs-ai-cant-replace/">Future of Jobs Report 2023</a>, sono agricoltura di precisione, trasporti intelligenti ed educazione personalizzata. In questi ambiti, l'intelligenza artificiale non sostituisce il lavoratore umano, ma ne amplifica enormemente le capacità. Un agronomo può oggi monitorare migliaia di ettari attraverso droni e sensori AI, un addetto alla logistica può ottimizzare rotte per centinaia di veicoli in tempo reale, un insegnante può personalizzare l'apprendimento per decine di studenti simultaneamente.</p>
-
 <p>La ricerca Microsoft ha dimostrato che le competenze del futuro non sono solo tecniche, ma includono soprattutto la capacità di collaborare efficacemente con sistemi di AI. Le interazioni più di successo tra umani e intelligenza artificiale mostrano che i migliori risultati si ottengono quando le persone sanno come formulare richieste precise, come verificare e raffinare le risposte dell'AI, e come integrare l'output artificiale con il giudizio e la creatività umana.</p>
-
 <p>Emerge una figura professionale completamente nuova: il "prompt engineer" o "AI whisperer", qualcuno che sa come comunicare efficacemente con l'intelligenza artificiale per ottenere risultati ottimali. Non serve una laurea in informatica per diventare esperti in questo campo, ma piuttosto una combinazione di curiosità, creatività e capacità di pensiero critico.</p>
-
 <p>Un altro settore in forte crescita è quello della supervisione etica dell'AI. Con l'aumentare della diffusione di questi strumenti, cresce la domanda di professionisti che possano garantire che l'intelligenza artificiale venga utilizzata in modo responsabile, trasparente e rispettoso dei diritti umani. Questi "AI Ethics Officer" rappresentano una professione completamente nuova che unisce competenze tecniche, filosofiche e legali.</p>
-
-<p><img src="job_increase.jpg" alt="job_increase.jpg" />
+<p><img alt="job_increase.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/10 - AI Posti di Lavoro/job_increase.jpg"/>
 <em><a href="https://www.weforum.org/stories/2023/09/jobs-ai-will-create/">Immagine tratta dal sito di World Economic Forum</a></em></p>
-
 <h2>Il saldo finale e le implicazioni sociali</h2>
-
 <p>Matematicamente parlando, i numeri sono tutto sommato incoraggianti. Il World Economic Forum prevede che la creazione netta di posti di lavoro riuscirà a compensare gran parte delle perdite, anche se con un saldo leggermente negativo. Tuttavia, la vera sfida non sta nei numeri aggregati, ma nella complessità della transizione e nella distribuzione geografica e sociale di questi cambiamenti.</p>
-
 <p>Il problema principale è che i nuovi lavori potrebbero non andare alle stesse persone che perdono quelli tradizionali. Un contabile di mezza età che vede il proprio ruolo automatizzato difficilmente diventerà uno specialista in machine learning da un giorno all'altro. Questa asimmetria temporale e qualitativa rappresenta la vera sfida sociale dell'era dell'AI.</p>
-
 <p>La questione territoriale aggiunge un ulteriore livello di complessità. I nuovi lavori legati all'intelligenza artificiale tendono a concentrarsi in specifiche aree metropolitane con ecosistemi tecnologici sviluppati, mentre i posti eliminati dall'automazione sono spesso distribuiti più uniformemente sul territorio. Questo rischia di accentuare i divari geografici ed economici esistenti, creando una nuova forma di disuguaglianza digitale.</p>
-
 <p>L'importanza della formazione continua emerge come fattore cruciale per gestire questa transizione. Come nei "Tempi moderni" di Chaplin, ogni rivoluzione industriale ha inizialmente creato spaesamento e timore, ma alla fine ha portato a un innalzamento generale del tenore di vita. La differenza oggi è nella velocità del cambiamento, che richiede sistemi educativi e formativi molto più agili e adattabili.</p>
-
 <p>Il reskilling e l'upskilling non sono più opzioni, ma necessità per chiunque voglia rimanere competitivo nel mercato del lavoro. Le aziende più lungimiranti stanno già investendo massicciamente nella riqualificazione dei propri dipendenti, riconoscendo che è più conveniente formare il personale esistente piuttosto che sostituirlo completamente.</p>
-
 <h2>Prepararsi al cambiamento</h2>
-
 <p>Le strategie individuali per navigare questa transizione richiedono prima di tutto un cambio di mentalità. L'adattabilità diventa la competenza più importante, più preziosa della conoscenza specifica di qualsiasi settore. Chi riesce a imparare continuamente, a reinventarsi professionalmente e a vedere le tecnologie emergenti come alleati piuttosto che nemici avrà sempre un vantaggio competitivo.</p>
-
 <p>Il ruolo delle istituzioni è fondamentale per facilitare questo cambiamento. Governi e aziende devono collaborare per creare programmi di formazione efficaci, reti di sicurezza sociale adeguate e politiche che favoriscano una transizione il più possibile equa e inclusiva. L'investimento nell'educazione digitale e nella formazione continua rappresenta la chiave per trasformare una potenziale crisi in un'opportunità di crescita collettiva.</p>
-
 <p>La capacità di apprendere continuamente diventa davvero il superpotere del ventunesimo secolo. In un mondo dove l'intelligenza artificiale evolve a ritmi esponenziali, la differenza la farà chi saprà evolversi insieme a lei, mantenendo sempre quelle caratteristiche unicamente umane che nessuna macchina potrà mai replicare: l'empatia, la creatività, il pensiero critico e la capacità di dare significato alle esperienze.</p>
-
 <h2>Conclusioni</h2>
-
 <p>L'intelligenza artificiale non è né il salvatore né il distruttore del lavoro umano che molti dipingono. È uno strumento potentissimo che, come tutte le grandi tecnologie della storia, ridefinirà profondamente il modo in cui lavoriamo, ma non necessariamente la quantità di lavoro disponibile. I dati scientifici mostrano un quadro complesso ma sostanzialmente ottimista, dove le opportunità create possono bilanciare i posti eliminati.</p>
-
 <p>La vera sfida non è tecnologica, ma sociale: come gestire una transizione che sarà inevitabilmente traumatica per molti, come garantire che i benefici dell'AI siano distribuiti equamente, come preparare le generazioni future a un mondo del lavoro in continua evoluzione. Se riusciremo a affrontare queste sfide con intelligenza, collaborazione e lungimiranza, l'intelligenza artificiale potrà davvero diventare il catalizzatore di una nuova era di prosperità condivisa.</p>
-
 <p>Il futuro del lavoro sarà quello che decideremo di costruire. L'intelligenza artificiale ci offre gli strumenti, ma spetta a noi scegliere come utilizzarli. La pillola rossa o blu di Matrix, alla fine, la scegliamo noi.</p>
 
             <div class="footer-back-button">

--- a/dist/11 - AI La rivoluzione HRM .html
+++ b/dist/11 - AI La rivoluzione HRM .html
@@ -162,98 +162,54 @@
         <div id="article-view">
             <a href="index.html" class="back-button">Torna indietro</a>
             <h1>"Quando la Dimensione Non Conta": La Rivoluzione del Modello HRM</h1>
-
 <p><em>di Dario Ferrero (VerbaniaNotizie.it)</em>
-<img src="hrm_le_dimensioni_non_contano.jpg" alt="hrm_le_dimensioni_non_contano.jpg" /></p>
-
+<img alt="hrm_le_dimensioni_non_contano.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/11 - AI La rivoluzione HRM /hrm_le_dimensioni_non_contano.jpg"/></p>
 <p><em>La più grande rivoluzione nell'intelligenza artificiale degli ultimi anni non arriva dai laboratori di OpenAI o Google, ma da una piccola startup di Singapore chiamata <a href="https://www.sapient.inc/">Sapient Intelligence</a>.</em></p>
-
 <p>Il protagonista di questa storia si chiama <a href="https://github.com/sapientinc/HRM">Hierarchical Reasoning Model</a> (HRM), un agente AI che sta facendo tremare le fondamenta dell'intero settore con una promessa apparentemente impossibile: ragionare meglio dei giganti dell'AI utilizzando una frazione delle loro risorse.</p>
-
 <p>Non si tratta del solito modello linguistico ingrandito fino all'inverosimile, né dell'ennesima variazione sul tema dei transformer. HRM è costruito diversamente, ispirato direttamente al funzionamento del cervello umano, e i risultati che sta ottenendo sono a dir poco sbalorditivi. Questo modello da appena 27 milioni di parametri, meno di un quarto rispetto al primo GPT, sta superando sistematicamente modelli quattro volte più grandi in compiti di ragionamento complesso. Come se non bastasse, viene addestrato con soli mille esempi per problema, mentre i suoi avversari richiedono montagne di dati e mesi di elaborazione sui server più potenti del mondo.</p>
-
 <p>Ma la vera magia di HRM non risiede nelle sue dimensioni contenute o nella sua efficienza di addestramento. La sua innovazione sta nel fatto che non si limita a elaborare informazioni come fanno tutti gli altri: ragiona davvero, emulando i processi cognitivi umani in modi che sembravano fantascienza fino a pochi mesi fa. E i risultati parlano chiaro: dove altri modelli falliscono completamente, HRM eccelle con una naturalezza che ricorda più un cervello pensante che una macchina calcolatrice.</p>
-
 <h2>Quando la Catena di Pensiero Si Spezza</h2>
-
 <p>Per capire l'importanza della rivoluzione portata da HRM, dobbiamo prima comprendere come funzionano i modelli di intelligenza artificiale attuali e perché i loro limiti stanno diventando sempre più evidenti. ChatGPT, Claude, Gemini e tutti i loro fratelli maggiori si basano su una tecnica chiamata "Chain of Thought" o catena di pensiero, un approccio che suona promettente ma nasconde fragilità strutturali profonde.</p>
-
 <p>Immaginate di dover risolvere un problema di matematica complesso scrivendo ogni passaggio con una penna indelebile, senza mai poter tornare indietro per verificare o correggere quello che avete scritto. È esattamente così che funzionano i modelli attuali: si guidano passo dopo passo attraverso un problema, quasi "parlando a se stessi" ad alta voce, ma se commettono anche un solo piccolo errore in questa catena, l'intera risposta può crollare come un castello di carte.</p>
-
 <p>Come spiegano i ricercatori di Sapient Intelligence nel loro <a href="https://arxiv.org/abs/2506.21734">paper scientifico</a>, "la catena di pensiero per il ragionamento è una stampella, non una soluzione soddisfacente. Si basa su decomposizioni fragili definite dall'uomo dove un singolo passo falso o un disordine dei passaggi può far deragliare completamente il processo di ragionamento".</p>
-
 <p>Il problema è ancora più profondo di quanto sembri. I modelli basati su transformer, l'architettura che domina l'AI moderna, eseguono sempre la stessa quantità di "pensiero" indipendentemente dalla difficoltà della domanda. È come se un detective dovesse dedicare esattamente lo stesso tempo e le stesse risorse per risolvere sia un furto di biciclette che un intricato caso di omicidio. Non possono dire "Questo è difficile, ho bisogno di più tempo per pensare" e non possono rivedere il proprio ragionamento una volta iniziato a generare la risposta.</p>
-
 <p>Questa rigidità ha conseguenze pratiche enormi. I modelli attuali sono costretti a tradurre ogni processo di ragionamento in linguaggio esplicito, producendo risposte lunghe, lente e spesso ridondanti. Peggio ancora, questa dipendenza dal linguaggio li rende vulnerabili a errori in cascata: se sbagliano un passaggio intermedio, tutto quello che segue è compromesso, indipendentemente da quanto potrebbero essere corrette le loro capacità di ragionamento di base.</p>
-
 <h2>L'Architettura che Imita il Cervello</h2>
-
 <p>HRM abbandona completamente questo paradigma, abbracciando un approccio radicalmente diverso che i suoi creatori descrivono come "ispirato al cervello". Non si tratta di una metafora superficiale o di marketing: l'architettura di HRM prende in prestito direttamente la strategia di decisione a strati del cervello umano, applicandola all'intelligenza artificiale con risultati che stanno ridefinendo cosa sia possibile nel campo del machine learning.</p>
-
 <p>Al cuore di HRM ci sono due componenti che lavorano in tandem come un duo perfettamente coordinato. Il primo è un pianificatore di alto livello, che potremmo immaginare come il "cervello strategico lento" che osserva il quadro generale, identifica il tipo di problema da risolvere e traccia una mappa generale dell'approccio da seguire. Il secondo è un esecutore di basso livello, il "processore veloce" che prende gli ordini dal pianificatore e li esegue con precisione e rapidità.</p>
-
 <p>L'analogia più calzante è quella di un maestro di scacchi che collabora con un assistente incredibilmente efficiente. Il maestro studia la scacchiera, pianifica la strategia generale e decide quale mossa fare, mentre l'assistente esegue fisicamente la mossa con precisione millimetrica. Ma qui la similitudine si fa ancora più interessante: i due non si limitano a un singolo scambio di informazioni, ma mantengono un dialogo continuo per tutta la durata del problema.</p>
-
 <p>Questo è il cuore dell'innovazione di HRM: il <a href="https://venturebeat.com/ai/new-ai-architecture-delivers-100x-faster-reasoning-than-llms-with-just-1000-training-examples/">loop di ragionamento gerarchico</a>. Il modulo di alto livello elabora un piano strategico e lo passa al modulo di basso livello, che lo esegue e restituisce i risultati. A questo punto, il modulo di alto livello analizza quello che è successo, aggiorna la sua strategia in base ai nuovi dati e fornisce al modulo di basso livello un nuovo sottoproblema raffinato su cui lavorare. Questo "botta e risposta" continua in cicli iterativi finché il modello non converge sulla soluzione ottimale.</p>
-
 <p>La bellezza di questo approccio è che permette a HRM di controllare e raffinare internamente il proprio ragionamento mentre sta ancora processando il problema, una capacità che la stragrande maggioranza degli altri modelli semplicemente non possiede. È come se, mentre risolvete quel problema di matematica con la penna indelebile, qualcuno vi permettesse improvvisamente di cancellare, riscrivere e ripensare ogni passaggio fino a quando non siete completamente sicuri della soluzione.</p>
-
 <p>Ma c'è di più. La versione più avanzata di HRM utilizza l'apprendimento per rinforzo per decidere autonomamente quante iterazioni sono necessarie per ogni tipo di compito, rendendolo ancora più simile al pensiero flessibile umano. Proprio come noi dedichiamo più tempo e energie mentali ai problemi complessi rispetto a quelli semplici, HRM impara a modulare i suoi cicli di ragionamento in base alla difficoltà intrinseca del problema che sta affrontando.
-<img src="ragionamento_gerarchico_hrm.jpg" alt="ragionamento_gerarchico_hrm.jpg" />
+<img alt="ragionamento_gerarchico_hrm.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/11 - AI La rivoluzione HRM /ragionamento_gerarchico_hrm.jpg"/>
 <em><a href="https://sapient.inc/">Immagine tratta da Sapient.inc HRM</a></em></p>
-
 <h2>Davide Contro Golia: I Numeri che Sconvolgono</h2>
-
 <p>I risultati ottenuti da HRM sui benchmark di ragionamento più difficili sono il tipo di numeri che fanno alzare le sopracciglia anche agli esperti più scettici del settore. Stiamo parlando di un modello con appena 27 milioni di parametri che non solo compete con giganti da miliardi di parametri, ma li supera sistematicamente in compiti che richiedono ragionamento profondo e astratto.</p>
-
 <p>Sul <a href="https://venturebeat.com/ai/openais-o3-shows-remarkable-progress-on-arc-agi-sparking-debate-on-ai-reasoning/">ARC-AGI benchmark</a>, considerato uno dei test più affidabili per misurare le capacità di ragionamento astratto e generalizzazione dell'intelligenza artificiale, HRM ha ottenuto un punteggio del 40,3%, superando modelli molto più grandi come o3-mini-high di OpenAI (34,5%) e Claude 3.7 Sonnet (21,2%). Non si tratta di piccole differenze statisticamente insignificanti: stiamo parlando di gap prestazionali sostanziali che, nel mondo dell'AI, equivalgono a salti generazionali.</p>
-
 <p>Ma è sui compiti di ragionamento più estremi che HRM dimostra veramente la sua superiorità architettonica. Nei test di Sudoku di livello estremo e nei labiriniti complessi, le differenze diventano abissali. HRM ha risolto il 55% dei Sudoku più difficili, mentre i modelli basati sulla catena di pensiero hanno ottenuto un sonoro 0%. Stesso risultato per i labiriniti a griglia 30x30: HRM ha trovato il percorso ottimale nel 74,5% dei casi, mentre i suoi competitori sono rimasti fermi al palo con lo 0%.</p>
-
 <p>È la versione AI dell'adagio di Yoda: 'La dimensione non conta. Guardami. Mi giudichi forse dalla mia dimensione?' Solo che in questo caso, la Forza è l'architettura gerarchica e Luke Skywalker sono i modelli da miliardi di parametri che continuano a schiantarsi nella palude.</p>
-
 <p>Questi non sono semplici numeri su una tabella: rappresentano la differenza tra un'intelligenza artificiale che può affrontare problemi complessi del mondo reale e una che si blocca di fronte a sfide che richiedono più di un ragionamento superficiale. È la differenza tra un assistente che può aiutarvi a navigare attraverso decisioni complesse e uno che può al massimo aiutarvi a scrivere email più eloquenti.</p>
-
 <p>Ma forse il dato più impressionante di tutti riguarda l'efficienza di addestramento. Mentre i modelli linguistici tradizionali richiedono dataset enormi estratti da tutto internet e mesi di elaborazione sui supercomputer più potenti del mondo, HRM viene addestrato con soli mille esempi per compito. Come ha dichiarato Guan Wang, uno dei fondatori di Sapient Intelligence, "potresti addestrarlo a Sudoku a livello professionale in due ore di GPU" – un'efficienza che definisce letteralmente "ridicola" nel senso migliore del termine.
-<img src="benchmark_hrm.jpg" alt="benchmark_hrm.jpg" />
+<img alt="benchmark_hrm.jpg" src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/11 - AI La rivoluzione HRM /benchmark_hrm.jpg"/>
 <em><a href="https://sapient.inc/">Immagine tratta da Sapient.inc HRM</a></em></p>
-
 <h2>Oltre i Benchmark: Una Rivoluzione Strutturale</h2>
-
 <p>I risultati impressionanti sui test standardizzati sono solo la punta dell'iceberg. La vera rivoluzione portata da HRM risiede nella sua capacità di risolvere problemi strutturali fondamentali che affliggono l'intera generazione attuale di modelli basati su transformer, problemi che fino a poco tempo fa sembravano parte inevitabile del panorama dell'intelligenza artificiale.</p>
-
 <p>Il primo e più significativo di questi problemi è l'efficienza della memoria. I transformer tradizionali sono notoriamente affamati di risorse, richiedendo quantità enormi di memoria per operare e ancora di più per essere addestrati. HRM, invece, utilizza aggiornamenti del gradiente più locali, che sono più facili da calcolare e "molto più biologicamente plausibili", evitando la famosa "profonda retropropagazione nel tempo" che è intensiva in termini di memoria e computazionalmente lenta.</p>
-
 <p>Questa efficienza di memoria non è un semplice miglioramento incrementale: è un cambiamento di paradigma che apre scenari completamente nuovi. Meno memoria significa poter eseguire più modelli contemporaneamente sullo stesso hardware, addestrare più velocemente con meno risorse, e soprattutto portare l'intelligenza artificiale avanzata su dispositivi che fino a ieri erano impensabili. Stiamo parlando di laptop comuni, dispositivi edge, robot, e persino automobili – tutti luoghi dove l'AI potrebbe operare in modo autonomo senza dipendere da connessioni internet costanti o server remoti.</p>
-
 <p>L'azienda Sapient sta già testando HRM in applicazioni del mondo reale che dimostrano questa versatilità. Nel settore sanitario, il modello viene utilizzato per aiutare nella diagnosi di malattie rare, quelle patologie complesse che richiedono esattamente il tipo di ragionamento profondo e sfumato in cui HRM eccelle. Nelle previsioni climatiche stagionali, ha raggiunto tassi di precisione del 97%, un risultato che nel mondo della meteorologia equivale quasi alla fantascienza.</p>
-
 <p>Ma forse l'aspetto più incoraggiante di HRM è il team che c'è dietro. Non si tratta di ricercatori sconosciuti che lavorano in garage: il gruppo include ex ingegneri di DeepMind, Anthropic, DeepSeek e persino del gruppo XAI di Elon Musk. Sono persone che hanno lavorato all'avanguardia dell'intelligenza artificiale per anni e che ora stanno scommettendo tutto sul design ispirato al cervello di HRM. Quando professionisti di questo calibro abbandonano le certezze dei grandi colossi tecnologici per inseguire una visione alternativa, vale la pena prestare attenzione.</p>
-
 <p>Guan Wang, il CEO e fondatore di Sapient Intelligence, non usa mezzi termini quando parla del futuro dell'intelligenza artificiale. La sua visione è che l'AGI, l'intelligenza artificiale generale, riguarda il dare alle macchine un'intelligenza a livello umano e oltre. E secondo Wang, la catena di pensiero è solo una "scorciatoia", mentre quello che hanno costruito "può pensare" nel vero senso della parola.</p>
-
 <h2>Open Source e Trasparenza: Un Regalo alla Comunità</h2>
-
 <p>In un'epoca in cui i grandi laboratori di AI tendono a mantenere segreti commerciali sempre più stretti sui loro modelli più avanzati, la decisione di Sapient Intelligence di rendere HRM completamente open source rappresenta un gesto di trasparenza quasi rivoluzionario. L'intero progetto è <a href="https://github.com/sapientinc/HRM">disponibile su GitHub</a>, permettendo a chiunque nel mondo di verificarlo, addestrare la propria versione, modificarlo o costruirci sopra. Questo livello di apertura è raro per un'innovazione così promettente e strategicamente importante.</p>
-
 <p>Naturalmente, HRM ha ancora dei limiti che i suoi creatori riconoscono apertamente. Per ora, il modello ha un focus più ristretto rispetto ai grandi modelli linguistici generalisti: è costruito per ragionare, non per chattare amichevolmente o scrivere poesia romantica. Ma proprio questa specializzazione è ciò che lo rende così potente nel suo dominio. È una delle prove di concetto più forti che il settore abbia mai visto per dimostrare che il futuro dell'AI potrebbe non risiedere in modelli sempre più grandi e generalisti, ma in architetture più intelligenti e specializzate.</p>
-
 <p>HRM non è l'unico esperimento di questo tipo in corso. Il panorama della ricerca AI sta vivendo un momento di effervescenza creativa, con team in tutto il mondo che esplorano architetture alternative ai transformer dominanti. C'è Sakana con le loro macchine a pensiero continuo, i modelli LLM a un bit che promettono efficienza estrema, e i modelli di ragionamento basati sulla diffusione di Google. Ma c'è una differenza cruciale: HRM "sta già funzionando" e superando modelli molto più grandi con una frazione dei dati di addestramento e senza bisogno di pre-addestramento massiccio.</p>
-
 <p>Questo suggerisce che stiamo assistendo a un cambiamento di paradigma fondamentale. Il prossimo grande salto nell'intelligenza artificiale probabilmente non sarà un altro "clone di GPT scalato" fino a dimensioni ancora più mastodontiche, ma qualcosa di simile a HRM: una nuova architettura che porta ragionamento migliore, addestramento più veloce e implementazione più economica, tutto senza la necessità di data center pieni di GPU che consumano l'elettricità di intere città.</p>
-
 <h2>Il Futuro che Pensa Davvero</h2>
-
 <p>Guardando avanti, la visione che emerge dal lavoro di HRM è quella di un futuro in cui l'intelligenza artificiale non sarà più confinata nei data center delle grandi corporation tecnologiche, ma diventerà una presenza pervasiva e accessibile nella nostra vita quotidiana. Immaginate agenti AI che vivono nei nostri laptop, nei robot domestici, nelle automobili, persino nei dispositivi indossabili, tutti capaci di ragionamento sofisticato senza dipendere da connessioni internet costanti o da server remoti costosi.</p>
-
 <p>Questa democratizzazione dell'intelligenza artificiale avanzata potrebbe avere implicazioni profonde per come lavoriamo, impariamo e risolviamo problemi. Un medico in una clinica rurale potrebbe avere accesso agli stessi strumenti di diagnosi avanzata di un ospedale metropolitano. Un ingegnere che lavora su un sito di costruzione remoto potrebbe ottenere analisi strutturali complesse in tempo reale. Un ricercatore in un laboratorio con budget limitato potrebbe esplorare ipotesi scientifiche complesse senza dover competere per l'accesso ai supercomputer.</p>
-
 <p>Ma forse l'aspetto più affascinante di tutti è l'idea che questi agenti AI non si limiteranno più a "parlare" con internet o a rigurgitare informazioni elaborate altrove. Inizieranno a "pensare realmente", nel senso più profondo del termine, elaborando soluzioni originali, formulando ipotesi creative, e magari anche sviluppando intuizioni che noi umani non avremmo mai considerato.</p>
-
 <p>Come ogni rivoluzione tecnologica, questa trasformazione porterà con sé nuove sfide e questioni etiche che dovremo affrontare. Ma se HRM e le architetture simili manterranno le loro promesse, potremmo essere alle soglie di un'era in cui l'intelligenza artificiale diventa finalmente quello che il nome promette: non solo un sofisticato sistema di elaborazione di informazioni, ma un vero partner intellettuale capace di ragionamento autonomo e creativo.</p>
-
 <p>Come direbbe Tony Stark, a volte la soluzione migliore non è costruire un'armatura più grande, ma costruirla più intelligente. E HRM potrebbe aver trovato il modo per rimpiazzare la forza bruta computazionale con qualcosa di molto più elegante ed efficiente.</p>
-
 <p>La strada è ancora lunga e piena di incognite, ma una cosa è certa: il piccolo modello da 27 milioni di parametri creato in una startup di Singapore ha già dimostrato che nel mondo dell'intelligenza artificiale, come spesso accade nella scienza, la qualità può davvero battere la quantità. E forse, proprio come nelle migliori storie di Davide contro Golia, è proprio il più piccolo a mostrarci la strada verso il futuro.</p>
 
             <div class="footer-back-button">

--- a/dist/index.html
+++ b/dist/index.html
@@ -161,7 +161,7 @@
         <div id="articles-grid">
 
         <a href="11 - AI La rivoluzione HRM .html" class="article-card">
-            <img src="hrm_le_dimensioni_non_contano.jpg" alt=""Quando la Dimensione Non Conta": La Rivoluzione del Modello HRM" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/11 - AI La rivoluzione HRM /hrm_le_dimensioni_non_contano.jpg" alt=""Quando la Dimensione Non Conta": La Rivoluzione del Modello HRM" loading="lazy">
             <div class="article-card-content">
                 <h3>"Quando la Dimensione Non Conta": La Rivoluzione del Modello HRM</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -170,7 +170,7 @@
         </a>
 
         <a href="10 - AI Posti di Lavoro.html" class="article-card">
-            <img src="work_wrestling.jpg" alt="L'Intelligenza Artificiale e il Futuro del Lavoro" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/10 - AI Posti di Lavoro/work_wrestling.jpg" alt="L'Intelligenza Artificiale e il Futuro del Lavoro" loading="lazy">
             <div class="article-card-content">
                 <h3>L'Intelligenza Artificiale e il Futuro del Lavoro</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -179,7 +179,7 @@
         </a>
 
         <a href="09 - AI Kimi K2 il nuovo sfidante.html" class="article-card">
-            <img src="DavideGolia_IA.jpg" alt="Kimi K2: L'Intelligenza Artificiale Cinese che Sfida i Giganti del Coding" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/09 - AI Kimi K2 il nuovo sfidante/DavideGolia_IA.jpg" alt="Kimi K2: L'Intelligenza Artificiale Cinese che Sfida i Giganti del Coding" loading="lazy">
             <div class="article-card-content">
                 <h3>Kimi K2: L'Intelligenza Artificiale Cinese che Sfida i Giganti del Coding</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -188,7 +188,7 @@
         </a>
 
         <a href="08-AI Musica e Copyright.html" class="article-card">
-            <img src="Band_AI.jpg" alt="Quando l'Intelligenza Artificiale fa musica: il fenomeno The Velvet Sundown e Iam tra tecnologia ed etica" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/08-AI Musica e Copyright/Band_AI.jpg" alt="Quando l'Intelligenza Artificiale fa musica: il fenomeno The Velvet Sundown e Iam tra tecnologia ed etica" loading="lazy">
             <div class="article-card-content">
                 <h3>Quando l'Intelligenza Artificiale fa musica: il fenomeno The Velvet Sundown e Iam tra tecnologia ed etica</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -197,7 +197,7 @@
         </a>
 
         <a href="07-AI Bocciati i Giganti.html" class="article-card">
-            <img src="GigantiTechAsini.jpg" alt="L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/07-AI Bocciati i Giganti/GigantiTechAsini.jpg" alt="L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)" loading="lazy">
             <div class="article-card-content">
                 <h3>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -206,7 +206,7 @@
         </a>
 
         <a href="06-AI Valutazione ed Etica.html" class="article-card">
-            <img src="Leonardo_Phoenix_An_ethically_charged_portrait_of_AIs_challeng_0.jpg" alt="Valutare l'Intelligenza Artificiale: Quando i Numeri Incontrano l'Etica" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/06-AI Valutazione ed Etica/Leonardo_Phoenix_An_ethically_charged_portrait_of_AIs_challeng_0.jpg" alt="Valutare l'Intelligenza Artificiale: Quando i Numeri Incontrano l'Etica" loading="lazy">
             <div class="article-card-content">
                 <h3>Valutare l'Intelligenza Artificiale: Quando i Numeri Incontrano l'Etica</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -215,7 +215,7 @@
         </a>
 
         <a href="05-AI Aziende e Servizi.html" class="article-card">
-            <img src="Leonardo_Phoenix_10_A_fiercely_competitive_scene_in_the_world_1.jpg" alt="Il Panorama dell'Intelligenza Artificiale: Giganti Tecnologici, Sfide Competitive e gli Strumenti che Democratizzano l'IA" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/05-AI Aziende e Servizi/Leonardo_Phoenix_10_A_fiercely_competitive_scene_in_the_world_1.jpg" alt="Il Panorama dell'Intelligenza Artificiale: Giganti Tecnologici, Sfide Competitive e gli Strumenti che Democratizzano l'IA" loading="lazy">
             <div class="article-card-content">
                 <h3>Il Panorama dell'Intelligenza Artificiale: Giganti Tecnologici, Sfide Competitive e gli Strumenti che Democratizzano l'IA</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -224,7 +224,7 @@
         </a>
 
         <a href="04-AI_Creazione_Contenuti.html" class="article-card">
-            <img src="Leonardo_Phoenix_10_a_cinematic_photograph_of_a_whimsical_arti_1.jpg" alt="AI e Creazione di Contenuti: Il Presente e il Futuro della Creatività Digitale" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/04-AI_Creazione_Contenuti/Leonardo_Phoenix_10_a_cinematic_photograph_of_a_whimsical_arti_1.jpg" alt="AI e Creazione di Contenuti: Il Presente e il Futuro della Creatività Digitale" loading="lazy">
             <div class="article-card-content">
                 <h3>AI e Creazione di Contenuti: Il Presente e il Futuro della Creatività Digitale</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -233,7 +233,7 @@
         </a>
 
         <a href="03-Dalle Applicazioni Consolidate alle Frontiere del Futuro.html" class="article-card">
-            <img src="fotocopertina2.jpg" alt="L'Intelligenza Artificiale Oggi: Dalle Applicazioni Consolidate alle Frontiere del Futuro" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/03-Dalle Applicazioni Consolidate alle Frontiere del Futuro/fotocopertina2.jpg" alt="L'Intelligenza Artificiale Oggi: Dalle Applicazioni Consolidate alle Frontiere del Futuro" loading="lazy">
             <div class="article-card-content">
                 <h3>L'Intelligenza Artificiale Oggi: Dalle Applicazioni Consolidate alle Frontiere del Futuro</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
@@ -242,7 +242,7 @@
         </a>
 
         <a href="02-Machine Learning, Deep Learning e Algoritmi Generativi Il Cuore Pulsante dell'Intelligenza Artificiale Moderna.html" class="article-card">
-            <img src="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_2.jpg" alt="Machine Learning, Deep Learning e Algoritmi Generativi: Il Cuore Pulsante dell'Intelligenza Artificiale Moderna" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/02-Machine Learning, Deep Learning e Algoritmi Generativi Il Cuore Pulsante dell'Intelligenza Artificiale Moderna/Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_2.jpg" alt="Machine Learning, Deep Learning e Algoritmi Generativi: Il Cuore Pulsante dell'Intelligenza Artificiale Moderna" loading="lazy">
             <div class="article-card-content">
                 <h3>Machine Learning, Deep Learning e Algoritmi Generativi: Il Cuore Pulsante dell'Intelligenza Artificiale Moderna</h3>
                 <p>di: Dario Ferrero (VerbaniaNotizie.it)
@@ -251,7 +251,7 @@
         </a>
 
         <a href="01-L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo.html" class="article-card">
-            <img src="Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_1.jpg" alt="L'Intelligenza Artificiale: Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo" loading="lazy">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/01-L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo/Leonardo_Phoenix_10_Create_a_thumbnail_to_accompany_the_journa_1.jpg" alt="L'Intelligenza Artificiale: Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo" loading="lazy">
             <div class="article-card-content">
                 <h3>L'Intelligenza Artificiale: Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo</h3>
                 <p>di: Dario Ferrero (VerbaniaNotizie.it)

--- a/dist/rss.xml
+++ b/dist/rss.xml
@@ -7,7 +7,7 @@
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>python-feedgen</generator>
     <language>it</language>
-    <lastBuildDate>Thu, 07 Aug 2025 11:23:00 +0000</lastBuildDate>
+    <lastBuildDate>Thu, 07 Aug 2025 11:29:37 +0000</lastBuildDate>
     <item>
       <title>L'Intelligenza Artificiale: Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo</title>
       <link>https://&lt;YOUR_USERNAME&gt;.github.io/&lt;YOUR_REPO&gt;/01-L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo.html</link>


### PR DESCRIPTION
Article images were not displaying on the deployed site because their `src` attributes were relative paths (e.g., `image.png`), which were broken after the site generation.

This commit updates the `process_article` function in `build.py` to:
- Parse the generated HTML content of each article.
- Find all `<img>` tags.
- Check if the `src` attribute is a relative path.
- If relative, rewrite it to be an absolute URL pointing to the raw image file in the source GitHub repository (`matteobaccan/CorsoAIBook`).

This ensures that all article images now have valid, absolute URLs and will render correctly on the live site.