### PR TITLE
fix: Correct sorting for multi-part articles

### DIFF
--- a/build.py
+++ b/build.py
@@ -74,9 +74,10 @@ def main():
 
     # 3. Process all articles from the markdown files
     processed_articles = []
-    # Sort files by parent directory name (desc) and then by file name (asc)
-    # This keeps articles grouped and parts in order
-    sorted_md_files = sorted(md_files, key=lambda x: (x['parent_dir'], x['name']), reverse=True)
+    # Sort files by name case-insensitively ascending to get parts in order
+    s1 = sorted(md_files, key=lambda x: x['name'].lower())
+    # Then sort by parent directory descending to get newest article groups first
+    sorted_md_files = sorted(s1, key=lambda x: x['parent_dir'], reverse=True)
 
     for md_file in sorted_md_files:
         article_data = process_article(md_file)

--- a/dist/rss.xml
+++ b/dist/rss.xml
@@ -7,7 +7,7 @@
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>python-feedgen</generator>
     <language>it</language>
-    <lastBuildDate>Thu, 07 Aug 2025 11:39:31 +0000</lastBuildDate>
+    <lastBuildDate>Thu, 07 Aug 2025 11:48:43 +0000</lastBuildDate>
     <item>
       <title>L'Intelligenza Artificiale: Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo</title>
       <link>https://&lt;YOUR_USERNAME&gt;.github.io/&lt;YOUR_REPO&gt;/L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo.html</link>


### PR DESCRIPTION
This commit fixes the sorting logic for articles to ensure that parts of a multi-part article are ordered correctly.

The previous sort was case-sensitive, leading to incorrect ordering of filenames like 'part1' and 'Part2'. The new logic implements a stable, two-step sort:
1.  First, sort all markdown files by their filename case-insensitively in ascending order. This ensures 'part1' always comes before 'part2'.
2.  Then, sort the resulting list by the parent directory name in descending order. This places the newest article groups at the top.

This change corrects the final known bug in the build logic.