### PR TITLE
fix: Reverse sort order for multi-part articles

### DIFF
--- a/build.py
+++ b/build.py
@@ -74,8 +74,8 @@ def main():
 
     # 3. Process all articles from the markdown files
     processed_articles = []
-    # Sort files by name case-insensitively ascending to get parts in order
-    s1 = sorted(md_files, key=lambda x: x['name'].lower())
+    # Sort files by name case-insensitively descending to get newest parts first
+    s1 = sorted(md_files, key=lambda x: x['name'].lower(), reverse=True)
     # Then sort by parent directory descending to get newest article groups first
     sorted_md_files = sorted(s1, key=lambda x: x['parent_dir'], reverse=True)
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -196,19 +196,19 @@
             </div>
         </a>
 
-        <a href="Giganti_Ai_Bocciati_prima_puntata.html" class="article-card">
-            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/07-AI Bocciati i Giganti/GigantiTechAsini.jpg" alt="L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Prima Puntata)" loading="lazy">
+        <a href="Giganti_AI_Bocciati_seconda_puntata.html" class="article-card">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/07-AI Bocciati i Giganti/GigantiTechAsini.jpg" alt="L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)" loading="lazy">
             <div class="article-card-content">
-                <h3>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Prima Puntata)</h3>
+                <h3>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
 </p>
             </div>
         </a>
 
-        <a href="Giganti_AI_Bocciati_seconda_puntata.html" class="article-card">
-            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/07-AI Bocciati i Giganti/GigantiTechAsini.jpg" alt="L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)" loading="lazy">
+        <a href="Giganti_Ai_Bocciati_prima_puntata.html" class="article-card">
+            <img src="https://raw.githubusercontent.com/matteobaccan/CorsoAIBook/main/articoli/07-AI Bocciati i Giganti/GigantiTechAsini.jpg" alt="L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Prima Puntata)" loading="lazy">
             <div class="article-card-content">
-                <h3>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)</h3>
+                <h3>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Prima Puntata)</h3>
                 <p>di Dario Ferrero (VerbaniaNotizie.it)
 </p>
             </div>

--- a/dist/rss.xml
+++ b/dist/rss.xml
@@ -7,7 +7,7 @@
     <docs>http://www.rssboard.org/rss-specification</docs>
     <generator>python-feedgen</generator>
     <language>it</language>
-    <lastBuildDate>Thu, 07 Aug 2025 12:04:20 +0000</lastBuildDate>
+    <lastBuildDate>Thu, 07 Aug 2025 12:13:54 +0000</lastBuildDate>
     <item>
       <title>L'Intelligenza Artificiale: Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo</title>
       <link>https://&lt;YOUR_USERNAME&gt;.github.io/&lt;YOUR_REPO&gt;/L'Intelligenza Artificiale - Un Viaggio nella Tecnologia Che Sta Ridefinendo il Nostro Mondo.html</link>
@@ -45,14 +45,14 @@
 </description>
     </item>
     <item>
-      <title>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)</title>
-      <link>https://&lt;YOUR_USERNAME&gt;.github.io/&lt;YOUR_REPO&gt;/Giganti_AI_Bocciati_seconda_puntata.html</link>
+      <title>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Prima Puntata)</title>
+      <link>https://&lt;YOUR_USERNAME&gt;.github.io/&lt;YOUR_REPO&gt;/Giganti_Ai_Bocciati_prima_puntata.html</link>
       <description>di Dario Ferrero (VerbaniaNotizie.it)
 </description>
     </item>
     <item>
-      <title>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Prima Puntata)</title>
-      <link>https://&lt;YOUR_USERNAME&gt;.github.io/&lt;YOUR_REPO&gt;/Giganti_Ai_Bocciati_prima_puntata.html</link>
+      <title>L'intelligenza artificiale senza controllo: le grandi aziende tech bocciate in sicurezza (Seconda Puntata)</title>
+      <link>https://&lt;YOUR_USERNAME&gt;.github.io/&lt;YOUR_REPO&gt;/Giganti_AI_Bocciati_seconda_puntata.html</link>
       <description>di Dario Ferrero (VerbaniaNotizie.it)
 </description>
     </item>


### PR DESCRIPTION
Based on your feedback, I've reversed the sorting logic for multi-part articles. The previous implementation sorted parts in ascending order (part 1, part 2), but the desired behavior is to show the newest part first.

This commit changes the filename sort from ascending to descending (`reverse=True`). This ensures that within an article group, parts are ordered from newest to oldest (e.g., part 2, part 1), matching your requirement.