### PR TITLE
fix: Improve language file fetching logic and fix 404 error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,17 +44,28 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Build the site
+      - name: Setup build environment
         run: |
-          # Clean the base dist directory once before starting
           if [ -d "dist" ]; then rm -r dist; fi
           mkdir dist
-          # Run build for each language
-          python3 build.py --lang it
-          python3 build.py --lang en
-          python3 build.py --lang es
+
+      - name: Build Italian site
+        run: python3 build.py --lang it
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build English site
+        run: python3 build.py --lang en
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Spanish site
+        run: python3 build.py --lang es
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create root redirect
+        run: python3 -c "from build import create_root_redirect; create_root_redirect()"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This commit introduces two critical fixes:
1.  A root `index.html` file is now generated in the `dist` directory. This file contains a meta refresh and JavaScript redirect to the default language subdirectory (`/it/`), fixing the 404 "File not found" error on the main site URL.
2.  The `fetch_markdown_files` function in `build.py` has been refactored for clarity and correctness. It now uses a more robust method to select the correct language file for a given article, with a proper fallback to Italian. This resolves a bug where local builds were failing to find any markdown files.

The GitHub Actions workflow is also updated to orchestrate the multi-language builds and the creation of the root redirect file correctly.