### PR TITLE
Feat: Update cron schedule to run twice daily

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,9 +8,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Runs on a schedule (e.g., once a day at 3 AM UTC)
+  # Runs on a schedule (e.g., at 06:00 and 18:00 UTC daily)
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 6,18 * * *'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
- Modified the cron schedule in the `deploy.yml` workflow to trigger a build and deploy at 06:00 and 18:00 UTC every day.