### PR TITLE
fix: Replace scheduled deploy with repository dispatch trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,16 @@
 name: Build and Deploy Site
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the default branch (for changes to the site itself)
   push:
     branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-  # Runs on a schedule (e.g., at 06:00 and 18:00 UTC daily)
-  schedule:
-    - cron: '0 6,18 * * *'
+  # Allows this workflow to be triggered by a remote repository
+  repository_dispatch:
+    types: [update-articles]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
The previous deployment process was based on a cron schedule that ran twice a day. This was inefficient as it triggered builds even when there were no content changes, and it was proving to be unreliable.

This commit replaces the schedule-based trigger with an event-driven one using `repository_dispatch`. The workflow is now triggered by a `dispatch` event sent from the content repository (`Dario-Fe/News-AI-blog`) whenever it is updated.

This makes the deployment process more efficient and reliable, ensuring the site is rebuilt only when new content is available.