### PR TITLE
feat: Add privacy policy page

### DIFF
--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -1,0 +1,7 @@
+<div id="privacy-page-container" style="padding: 20px; max-width: 800px; margin: 40px auto; background-color: #ffffff; border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); text-align: left; line-height: 1.6;">
+    <h1 style="text-align: center;">Privacy Policy</h1>
+    <p>Questo sito non raccoglie dati personali di alcun tipo, ad eccezione del nome e dell'indirizzo email forniti volontariamente dagli utenti che si iscrivono alla nostra newsletter. Il nostro obiettivo non è raccogliere informazioni su di voi, ma condividere la passione per l'intelligenza artificiale e il mondo tech.</p>
+    <p>I dati forniti (nome ed email) vengono utilizzati esclusivamente per inviarti aggiornamenti, articoli e novità tramite la nostra newsletter. Non condivideremo mai queste informazioni con terze parti senza il tuo esplicito consenso.</p>
+    <p>Il sito è ospitato su Netlify, che potrebbe raccogliere dati anonimi per scopi tecnici, come la protezione da attività dannose e la manutenzione del servizio. Per maggiori dettagli, puoi consultare l'<a href="https://www.netlify.com/privacy/" target="_blank" rel="noopener noreferrer">Informativa sulla privacy di Netlify</a>.</p>
+    <p>Se desideri modificare, cancellare i tuoi dati o smettere di ricevere la newsletter, puoi contattarci in qualsiasi momento o utilizzare il link di cancellazione presente in ogni email.</p>
+</div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -214,7 +214,7 @@
         <p>
             <a href="mailto:info@verbanianotizie.it">{{footer_contacts}}</a> |
             <a href="cookie.html">Cookie</a> |
-            <a href="#">Privacy Policy</a>
+            <a href="privacy.html">Privacy Policy</a>
         </p>
     </footer>
 </body>


### PR DESCRIPTION
I've introduced a new privacy policy page to the website.

- I created a new file, `pages/privacy.html`, with the site's privacy policy statement.
- I updated the base template, `templates/base.html`, to link to this new page from the footer.

This fulfills your request to add a privacy information page.