### PR TITLE
feat: Add tags and date display and filtering

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -187,6 +187,42 @@
             margin: 40px auto;
             text-align: center;
         }
+        .article-card-date {
+            font-size: 0.8em;
+            color: #606770;
+            margin-bottom: 10px;
+        }
+        .article-card-tags {
+            margin-top: 15px;
+        }
+        .tag {
+            display: inline-block;
+            background-color: #e7f3ff;
+            color: #1877f2;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.75em;
+            font-weight: bold;
+            margin-right: 5px;
+            margin-bottom: 5px;
+        }
+        .tag-filter-button {
+            padding: 8px 16px;
+            border: 1px solid #ddd;
+            border-radius: 20px;
+            background-color: #fff;
+            cursor: pointer;
+            transition: all 0.2s;
+            font-size: 0.9em;
+        }
+        .tag-filter-button:hover {
+            background-color: #f0f2f5;
+        }
+        .tag-filter-button.active {
+            background-color: #1877f2;
+            color: white;
+            border-color: #1877f2;
+        }
     </style>
 </head>
 <body>
@@ -217,5 +253,34 @@
             <a href="#">Privacy Policy</a>
         </p>
     </footer>
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const filterButtons = document.querySelectorAll('.tag-filter-button');
+            if (!filterButtons.length) return;
+
+            const articleCards = document.querySelectorAll('.article-card');
+
+            filterButtons.forEach(button => {
+                button.addEventListener('click', function(e) {
+                    e.preventDefault(); // Prevent the link behavior on the anchor
+
+                    // Manage active state
+                    filterButtons.forEach(btn => btn.classList.remove('active'));
+                    this.classList.add('active');
+
+                    const selectedTag = this.getAttribute('data-tag');
+
+                    articleCards.forEach(card => {
+                        const cardTags = card.getAttribute('data-tags');
+                        if (selectedTag === 'all' || (cardTags && cardTags.includes(selectedTag))) {
+                            card.style.display = 'block';
+                        } else {
+                            card.style.display = 'none';
+                        }
+                    });
+                });
+            });
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This commit implements a new feature for tagging and filtering articles, built from a clean state to ensure correctness.

- The build script (`build.py`) is updated to read `tags` and `date` from the article frontmatter.
- The homepage (`generate_index_page`) is updated to display a filter bar with a button for each tag.
- Each article card on the homepage now displays its publication date and its associated tags.
- The original article sorting logic (by directory and filename) is preserved as requested.
- Client-side JavaScript has been added to `templates/base.html` to enable instant filtering of articles when a tag is selected.