### PR TITLE
feat: Add clickable tags within articles

### DIFF
--- a/build.py
+++ b/build.py
@@ -421,13 +421,24 @@ def generate_article_pages(articles, output_dir, lang='it'):
         # Get translation for the back button
         back_button_text = TRANSLATIONS["article_page"]["back_button"].get(lang, TRANSLATIONS["article_page"]["back_button"]["it"])
 
+        # --- Tags Formatting ---
+        tags_html = ""
+        if article.get('tags'):
+            tags_html = '<div class="article-card-tags" style="margin-bottom: 20px;">'
+            for tag in article['tags']:
+                # The link will point to the homepage with a hash for the JS to pick up
+                tags_html += f'<a href="index.html#{tag}" class="tag">{tag}</a>'
+            tags_html += '</div>'
+
         # Create a simple view for the article content
         article_view_html = f"""
         <div id="article-view">
             <a href="index.html" class="back-button">{back_button_text}</a>
+            {tags_html}
             {article['html_content']}
             <div class="footer-back-button">
-                <a href="index.html" class="back-button">{back_button_text}</a>
+                {tags_html}
+                <a href="index.html" class="back-button" style="margin-top: 20px;">{back_button_text}</a>
             </div>
         </div>
         """

--- a/templates/base.html
+++ b/templates/base.html
@@ -260,26 +260,58 @@
 
             const articleCards = document.querySelectorAll('.article-card');
 
+            function filterArticles(selectedTag) {
+                // Manage active state for buttons
+                filterButtons.forEach(btn => {
+                    if (btn.getAttribute('data-tag') === selectedTag) {
+                        btn.classList.add('active');
+                    } else {
+                        btn.classList.remove('active');
+                    }
+                });
+
+                // Filter cards
+                articleCards.forEach(card => {
+                    const cardTags = card.getAttribute('data-tags');
+                    if (selectedTag === 'all' || (cardTags && cardTags.includes(selectedTag))) {
+                        card.style.display = 'block';
+                    } else {
+                        card.style.display = 'none';
+                    }
+                });
+            }
+
+            // Add click listeners to buttons
             filterButtons.forEach(button => {
                 button.addEventListener('click', function(e) {
-                    e.preventDefault(); // Prevent the link behavior on the anchor
-
-                    // Manage active state
-                    filterButtons.forEach(btn => btn.classList.remove('active'));
-                    this.classList.add('active');
-
+                    e.preventDefault(); // Prevent default anchor behavior
                     const selectedTag = this.getAttribute('data-tag');
-
-                    articleCards.forEach(card => {
-                        const cardTags = card.getAttribute('data-tags');
-                        if (selectedTag === 'all' || (cardTags && cardTags.includes(selectedTag))) {
-                            card.style.display = 'block';
-                        } else {
-                            card.style.display = 'none';
-                        }
-                    });
+                    filterArticles(selectedTag);
+                    // Update URL hash for shareable links, without reloading the page
+                    if (history.pushState) {
+                        history.pushState(null, null, `#${selectedTag}`);
+                    } else {
+                        window.location.hash = `#${selectedTag}`;
+                    }
                 });
             });
+
+            // Function to apply filter based on the URL hash
+            function applyFilterFromHash() {
+                if (window.location.hash) {
+                    const tagFromHash = decodeURIComponent(window.location.hash.substring(1));
+                    const targetButton = document.querySelector(`.tag-filter-button[data-tag="${tagFromHash}"]`);
+                    if (targetButton) {
+                        filterArticles(tagFromHash);
+                    }
+                }
+            }
+
+            // Apply filter on initial page load
+            applyFilterFromHash();
+
+            // Also apply filter when the hash changes (e.g., back/forward buttons)
+            window.addEventListener('hashchange', applyFilterFromHash);
         });
     </script>
 </body>


### PR DESCRIPTION
This commit adds clickable tags to the individual article pages, allowing users to navigate back to the homepage with a specific tag filter applied.

- The `generate_article_pages` function in `build.py` now generates and injects a list of clickable tags at the top and bottom of each article. The links are formatted with a URL hash (e.g., `index.html#Business`).
- The JavaScript in `templates/base.html` has been enhanced to read the URL hash on page load and on hash change events, automatically applying the corresponding filter.
- The script has been refactored into a reusable function for better code structure.