### PR TITLE
Suspend GitHub Pages Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,23 +12,22 @@ on:
   repository_dispatch:
     types: [update-articles]
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Sets permissions of the GITHUB_TOKEN to allow deployment
 permissions:
   contents: read
-  pages: write
-  id-token: write
+  # pages: write      # Disattivato per sospensione GitHub Pages
+  # id-token: write   # Disattivato per sospensione GitHub Pages
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment
 concurrency:
-  group: "pages"
+  group: "deploy"
   cancel-in-progress: false
 
 jobs:
   build-and-deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    # environment:
+    #   name: github-pages
+    #   url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -69,14 +68,14 @@ jobs:
       - name: Build the site
         run: ./build.sh
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './dist'
+      # - name: Upload artifact
+      #   uses: actions/upload-pages-artifact@v3
+      #   with:
+      #     path: './dist'
 
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      # - name: Deploy to GitHub Pages
+      #   id: deployment
+      #   uses: actions/deploy-pages@v4
 
       - name: Deploy to Netlify
         run: npx netlify-cli deploy --dir=dist --prod


### PR DESCRIPTION
This change suspends the automatic deployment to GitHub Pages by commenting out the relevant steps in the GitHub Actions workflow. This was necessary because the build artifact size (~1.14 GB) exceeded GitHub's 1 GB limit, causing deployment failures. The site generation logic and the deployment to Netlify (aitalk.it) remain fully functional and unaffected.

---
*PR created automatically by Jules for task [8084123443960646047](https://jules.google.com/task/8084123443960646047) started by @Dario-Fe*